### PR TITLE
List should match service exactly

### DIFF
--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -172,7 +172,7 @@ func (s *SSMStore) List(service string, includeValues bool) ([]Secret, error) {
 			Filters: []*ssm.ParametersFilter{
 				{
 					Key:    aws.String("Name"),
-					Values: []*string{aws.String(service)},
+					Values: []*string{aws.String(service + ".")},
 				},
 			},
 			NextToken: nextToken,

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -292,6 +292,16 @@ func TestList(t *testing.T) {
 			assert.Equal(t, "value", *secret.Value)
 		}
 	})
+
+	t.Run("List should only return exact matches on service name", func(t *testing.T) {
+		store.Write(SecretId{Service: "match", Key: "a"}, "val")
+		store.Write(SecretId{Service: "matchlonger", Key: "a"}, "val")
+
+		s, err := store.List("match", false)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(s))
+		assert.Equal(t, "match.a", s[0].Meta.Key)
+	})
 }
 
 func TestHistory(t *testing.T) {


### PR DESCRIPTION
Before this change, list could match services by prefix, which is pretty undesirable.  Includes a test so we don't regress

