### PR TITLE
replace dashes with underscores when exporting to the environment

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -63,6 +63,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		}
 		for _, secret := range secrets {
 			envVarKey := strings.ToUpper(key(secret.Meta.Key))
+			envVarKey = strings.Replace(envVarKey, "-", "_", -1)
 
 			if env.IsSet(envVarKey) {
 				fmt.Fprintf(os.Stderr, "warning: overwriting environment variable %s\n", envVarKey)


### PR DESCRIPTION
Environment variables with dashes are generally not supported by most shells.  This replaces any dashes in the key name with underscores instead.