### PR TITLE
use paths instead of '.' separating

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Chamber does not currently read the value of "AWS_DEFAULT_REGION". See
 [https://github.com/aws/aws-sdk-go#configuring-aws-region](https://github.com/aws/aws-sdk-go#configuring-aws-region)
 for more details.
 
+### Using Path Based Keys
+
+If you'd prefer to use path based keys (`/service/key`) instead of the default period separated keys (`service.key`), you
+can set the environment variable `CHAMBER_USE_PATHS` to 1.  This environment variable must be set when writing and reading keys.
+
+
 ## Releasing
 
 To cut a new release, just push a tag named `v<semver>` where `<semver>` is a

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -55,7 +55,14 @@ func list(cmd *cobra.Command, args []string) error {
 }
 
 func key(s string) string {
+	_, usePaths := os.LookupEnv("CHAMBER_USE_PATHS")
+	if usePaths {
+		tokens := strings.Split(s, "/")
+		secretKey := tokens[2]
+		return secretKey
+	}
+
 	tokens := strings.Split(s, ".")
-	secretKey := tokens[1]
+ 	secretKey := tokens[1]
 	return secretKey
 }

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -281,9 +281,9 @@ func TestList(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(s))
 		sort.Sort(ByKey(s))
-		assert.Equal(t, "test.a", s[0].Meta.Key)
-		assert.Equal(t, "test.b", s[1].Meta.Key)
-		assert.Equal(t, "test.c", s[2].Meta.Key)
+		assert.Equal(t, "/test/a", s[0].Meta.Key)
+		assert.Equal(t, "/test/b", s[1].Meta.Key)
+		assert.Equal(t, "/test/c", s[2].Meta.Key)
 	})
 
 	t.Run("List should not return values if includeValues is false", func(t *testing.T) {
@@ -309,7 +309,7 @@ func TestList(t *testing.T) {
 		s, err := store.List("match", false)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(s))
-		assert.Equal(t, "match.a", s[0].Meta.Key)
+		assert.Equal(t, "/match/a", s[0].Meta.Key)
 	})
 }
 


### PR DESCRIPTION
This is a rough minimum edit change for using paths instead of dot separators.  If we go forward with this we should also:

- Update Describe and Get calls to use the Path options instead of string prefixing
- Bump to v2 as this is a breaking API change, probably put a notice in the readme as well