### PR TITLE
sometime results have empty pages, account for that

### DIFF
--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -144,6 +144,15 @@ func (m *mockSSMClient) DescribeParameters(i *ssm.DescribeParametersInput) (*ssm
 	}, nil
 }
 
+func (m *mockSSMClient) DescribeParametersPages(i *ssm.DescribeParametersInput, fn func(*ssm.DescribeParametersOutput, bool) bool) error {
+	o, err := m.DescribeParameters(i)
+	if err != nil {
+		return err
+	}
+	fn(o, true)
+	return nil
+}
+
 func paramNameInSlice(name *string, slice []*string) bool {
 	for _, val := range slice {
 		if *val == *name {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,160 +3,176 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "W/q89+AUzZNVNySmkHKFERn7OxY=",
+			"checksumSHA1": "BAGzIXWxLqZRXtZohIsib8o6XIw=",
+			"path": "github.com/aws/aws-sdk-go",
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
+		},
+		{
+			"checksumSHA1": "VGCkLl9kLkVD9pLTJMyFMy3C1Lo=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "iThCyNRL/oQFD9CF2SYgBGl+aww=",
+			"checksumSHA1": "n98FANpNeRT5kf6pizdpI7nm6Sw=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "0Gfk83qXYimO87ZoK1lL9+ifWHo=",
+			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "zu5C95rmCZff6NYZb62lEaT5ibE=",
+			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "6cj/zsRmcxkE1TLS+v910GbQYg0=",
+			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "l2O7P/kvovK2zxKhuFehFNXLk+Q=",
+			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "31f7CpCeRUQrUidzHj2uNwpBfCY=",
+			"checksumSHA1": "PQSXZY7ayypkyZm4FlI3m+G+o4k=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "junFAYG8KDpoHN9J0dkQDJHG1UA=",
+			"checksumSHA1": "n/tgGgh0wICYu+VDYSqlsRy4w9s=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "5pzA5afgeU1alfACFh8z2CDUMao=",
+			"checksumSHA1": "SK5Mn4Ga9+equOQTYA1DTSb3LWY=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "SvIsunO8D9MEKbetMENA4WRnyeE=",
+			"checksumSHA1": "iywvraxbXf3A/FOzFWjKfBBEQRA=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
+		},
+		{
+			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
+			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "Drt1JfLMa0DQEZLWrnMlTWaIcC8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "lZ1z4xAbT8euCzKoAsnEYic60VE=",
+			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "O1hCpo/BItZs+ADL7VXveRKn5yg=",
+			"checksumSHA1": "jCWrivRK+K+oW2ZW3sJSuBIBNjQ=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "395UEmdKXxyTMbFvexUzR/y1X8o=",
+			"checksumSHA1": "cAxlijULuvw8KAphHrR1+u3+AM0=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm/ssmiface",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "o8O6Fn1ThDBMRb5OKU3UBziey+A=",
+			"checksumSHA1": "MerduaV3PxtZAWvOGpgoBIglo38=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
+		},
+		{
+			"path": "github.com/aws/aws-sdk-go/ssm",
+			"revision": ""
 		},
 		{
 			"checksumSHA1": "jqSVRDK7dGg6E/NikVq1Kw6gdbA=",


### PR DESCRIPTION
With the new AWS fix, we often encounter blank pages before the ones we were looking for, so use the paginator API instead