### PR TITLE
adding more descriptive errors

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -54,12 +54,12 @@ func execRun(cmd *cobra.Command, args []string) error {
 	secretStore := store.NewSSMStore()
 	for _, service := range args {
 		if err := validateService(service); err != nil {
-			return err
+			return errors.Wrap(err, "Failed to validate service")
 		}
 
 		secrets, err := secretStore.List(strings.ToLower(service), true)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Failed to list store contents")
 		}
 		for _, secret := range secrets {
 			envVarKey := strings.ToUpper(key(secret.Meta.Key))
@@ -92,7 +92,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	var waitStatus syscall.WaitStatus
 	if err := ecmd.Run(); err != nil {
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Failed to run command")
 		}
 		if exitError, ok := err.(*exec.ExitError); ok {
 			waitStatus = exitError.Sys().(syscall.WaitStatus)

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -31,12 +32,12 @@ func history(cmd *cobra.Command, args []string) error {
 
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate key")
 	}
 
 	secretStore := store.NewSSMStore()
@@ -47,7 +48,7 @@ func history(cmd *cobra.Command, args []string) error {
 
 	events, err := secretStore.History(secretId)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Failed to get history")
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -31,13 +32,13 @@ func list(cmd *cobra.Command, args []string) error {
 
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	secretStore := store.NewSSMStore()
 	secrets, err := secretStore.List(service, false)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Failed to list store contents")
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -38,12 +39,12 @@ func read(cmd *cobra.Command, args []string) error {
 
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate key")
 	}
 
 	secretStore := store.NewSSMStore()
@@ -54,7 +55,7 @@ func read(cmd *cobra.Command, args []string) error {
 
 	secret, err := secretStore.Read(secretId, version)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Failed to read")
 	}
 
 	if quiet {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		fmt.Fprintf(os.Stderr, "chamber error: %s\n", err)
 		switch err {
 		case ErrTooFewArguments, ErrTooManyArguments:
 			RootCmd.Usage()

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -34,12 +34,12 @@ func write(cmd *cobra.Command, args []string) error {
 
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate key")
 	}
 
 	value := args[2]

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -202,6 +202,12 @@
 			"revisionTime": "2017-03-23T00:38:48Z"
 		},
 		{
+			"checksumSHA1": "9guv02oL7uLkwqQNjJv8AJxWXmQ=",
+			"path": "github.com/pkg/errors",
+			"revision": "ff09b135c25aae272398c51a07235b90a75aa4f0",
+			"revisionTime": "2017-03-16T20:15:38Z"
+		},
+		{
 			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",


### PR DESCRIPTION
After setting up chamber to wrap my app, I had some mysterious failures and found this in my logs:
```
ThrottlingException: Rate exceeded
        status code: 400, request id: aacd7f1b-a7b6-11e7-9180-0708e1f58f4b
```
It took me a while to track down that that was coming from chamber rather than something within my application.
This change adds some decoration to the errors created by chamber to more clearly identify it as the source of the error message, as well as adding a bit more depth to the message to aid diagnosis.
A sample error now looks like this:
```
➜  ./chamber list dev
chamber error: Failed to list store contents: MissingRegion: could not find region configuration
```