### PR TITLE
use syscall.Exec instead of exec.Command

### DIFF
--- a/cmd/exec_default.go
+++ b/cmd/exec_default.go
@@ -21,7 +21,7 @@ func exec(command string, args []string, env []string) error {
 	ecmd.Stderr = os.Stderr
 	ecmd.Env = env
 
-	signals := make([]os.Signal, 31)
+	signals := make([]os.Signal, 30)
 	for i := range signals {
 		signals[i] = syscall.Signal(i + 1)
 	}

--- a/cmd/exec_default.go
+++ b/cmd/exec_default.go
@@ -1,0 +1,52 @@
+// +build !linux,!darwin
+
+package cmd
+
+import (
+	"os"
+	osexec "os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// exec executes the given command, passing it args and setting its environment
+// to env.
+// The exec function is allowed to never return and cause the program to exit.
+func exec(command string, args []string, env []string) error {
+	ecmd := osexec.Command(command, args...)
+	ecmd.Stdin = os.Stdin
+	ecmd.Stdout = os.Stdout
+	ecmd.Stderr = os.Stderr
+	ecmd.Env = env
+
+	signals := make([]os.Signal, 31)
+	for i := range signals {
+		signals[i] = syscall.Signal(i + 1)
+	}
+
+	// Forward SIGINT, SIGTERM, SIGKILL to the child command
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, signals...)
+
+	go func() {
+		sig := <-sigChan
+		if ecmd.Process != nil {
+			ecmd.Process.Signal(sig)
+		}
+	}()
+
+	var waitStatus syscall.WaitStatus
+	if err := ecmd.Run(); err != nil {
+		if err != nil {
+			return errors.Wrap(err, "Failed to run command")
+		}
+		if exitError, ok := err.(*osexec.ExitError); ok {
+			waitStatus = exitError.Sys().(syscall.WaitStatus)
+			os.Exit(waitStatus.ExitStatus())
+		}
+	}
+
+	return nil
+}

--- a/cmd/exec_default.go
+++ b/cmd/exec_default.go
@@ -29,8 +29,10 @@ func exec(command string, args []string, env []string) error {
 	}
 
 	go func() {
-		sig := <-sigChan
-		ecmd.Process.Signal(sig)
+		for {
+			sig := <-sigChan
+			ecmd.Process.Signal(sig)
+		}
 	}()
 
 	if err := ecmd.Wait(); err != nil {

--- a/cmd/exec_unix.go
+++ b/cmd/exec_unix.go
@@ -1,0 +1,22 @@
+// +build linux darwin
+
+package cmd
+
+import (
+	osexec "os/exec"
+	"syscall"
+)
+
+func exec(command string, args []string, env []string) error {
+	argv0, err := osexec.LookPath(command)
+	if err != nil {
+		return err
+	}
+
+	argv := make([]string, 0, 1+len(args))
+	argv = append(argv, command)
+	argv = append(argv, args...)
+
+	// Only return if the execution fails.
+	return syscall.Exec(argv0, argv, env)
+}


### PR DESCRIPTION
Fixes #37 

Seems like it works, I would take some advises on how to better test this:
```
$ aws-vault exec stage -- ./chamber exec service -- env
TERM_PROGRAM=iTerm.app
EDITOR_DEFAULT=subl
TERM=xterm-256color
SHELL=/bin/bash
...
```
(not sure what env var we're supposed to see getting set here, also I just learned by default editor is sublime... what a shame)

Here are the changes I made:
- move the fallback execution logic (copy/pasting) to `exec_default.go`
- add the execution based on syscall.Exec in `exec_unix.go` with build tags to use it on unix systems
- change the default execution logic to forward all signals from 1 to 31, so on platforms other than linux and darwin we do our best not to mask signals intended to the program ran by chamber.

Please let me know if anything should be changed.