### PR TITLE
Delete entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ that is unneeded. Parameter store automatically versions secrets and passing
 the `--version/-v` flag to read can print older versions of the secret. Default
 version (-1) is the latest secret.
 
+
+### Deleting
+```bash
+$ chamber delete service key
+```
+
+`delete` provides the ability to remove a secret from chamber permanently,
+including the secret's additional metadata. There is no way to recover a
+secret once it has been deleted so care should be taken with this command.
+
 ### AWS Region
 
 Chamber uses [AWS SDK for Go](https://github.com/aws/aws-sdk-go). To use a

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/chamber/store"
+	"github.com/spf13/cobra"
+)
+
+// deleteCmd represents the delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete <service> <key>",
+	Short: "Delete a secret, including all versions",
+	RunE:  delete,
+}
+
+func init() {
+	RootCmd.AddCommand(deleteCmd)
+}
+
+func delete(cmd *cobra.Command, args []string) error {
+	if len(args) < 2 {
+		return ErrTooFewArguments
+	}
+	if len(args) > 2 {
+		return ErrTooManyArguments
+	}
+
+	service := strings.ToLower(args[0])
+	if err := validateService(service); err != nil {
+		return errors.Wrap(err, "Failed to validate service")
+	}
+
+	key := strings.ToLower(args[1])
+	if err := validateKey(key); err != nil {
+		return errors.Wrap(err, "Failed to validate key")
+	}
+
+	secretStore := store.NewSSMStore(numRetries)
+	secretId := store.SecretId{
+		Service: service,
+		Key:     key,
+	}
+
+	return secretStore.Delete(secretId)
+}

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -28,6 +28,9 @@ var validPathKeyFormat = regexp.MustCompile(`^\/[A-Za-z0-9-_]+\/[A-Za-z0-9-_]+$`
 // not using paths
 var validKeyFormat = regexp.MustCompile(`^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$`)
 
+// ensure SSMStore confirms to Store interface
+var _ Store = &SSMStore{}
+
 // SSMStore implements the Store interface for storing secrets in SSM Parameter
 // Store
 type SSMStore struct {

--- a/store/store.go
+++ b/store/store.go
@@ -57,4 +57,5 @@ type Store interface {
 	Read(id SecretId, version int) (Secret, error)
 	List(service string, includeValues bool) ([]Secret, error)
 	History(id SecretId) ([]ChangeEvent, error)
+	Delete(id SecretId) error
 }


### PR DESCRIPTION
This PR addresses an issue I had where an incorrect secret key was added to a service and there seemed to be no way of removing this key once it was there. 

It adds the following command:

```bash
$ chamber del service key
```

command, which just attempts to delete the specified key for that service using `ssm.DeleteParameter`.

This PR relates to #20, but is more limited in scope in that it does not attempt to address deleting an entire service, just removing a single bad key from the service. Would be interested in any feedback on this approach. I have tried out the functionality locally, and it seemed to work, but I don't fully understand the underlying storage mechanism on AWS.