### PR TITLE
exec: utilize `ErrCommandMissing`

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -40,7 +40,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(commandPart) == 0 {
-		return errors.New("must specify command to run")
+		return ErrCommandMissing
 	}
 
 	command := commandPart[0]


### PR DESCRIPTION
Debugging something and noticed this. Figured I'd send a quick patch to fix =]