### PR TITLE
Allow to use a custom AWS SSM endpoint

### DIFF
--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -340,7 +340,7 @@ func TestHistory(t *testing.T) {
 		assert.Equal(t, Created, events[0].Type)
 	})
 
-	t.Run("Histor should return create followed by updates for keys that have been updated", func(t *testing.T) {
+	t.Run("History should return create followed by updates for keys that have been updated", func(t *testing.T) {
 		events, err := store.History(SecretId{Service: "test", Key: "update"})
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(events))


### PR DESCRIPTION
This PR allows to use chamber with [localstack](https://github.com/localstack/localstack) once https://github.com/spulec/moto/pull/1348 (AWS SSM mock) will be merged. As a result chamber can be used in development, while using docker-compose for example, without needing a real AWS account.

Questions:
- Is the `CHAMBER_AWS_SSM_ENDPOINT` env. var. name appropriate ?
- Does it need a unit test ?
- Where to document this option (README ?) ?