### PR TITLE
Allow overriding region

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Chamber does not currently read the value of "AWS_DEFAULT_REGION". See
 [https://github.com/aws/aws-sdk-go#configuring-aws-region](https://github.com/aws/aws-sdk-go#configuring-aws-region)
 for more details.
 
+If you'd like to use a different region for chamber without changing `AWS_REGION`, you can use `CHAMBER_AWS_REGION` to override just for chamber.
+
 ### Using Path Based Keys
 
 If you'd prefer to use path based keys (`/service/key`) instead of the default period separated keys (`service.key`), you

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -47,6 +47,10 @@ func NewSSMStore(numRetries int) *SSMStore {
 		region, _ = ec2metadataSvc.Region()
 	}
 
+	if regionOverride, ok := os.LookupEnv("CHAMBER_AWS_REGION"); ok {
+		region = regionOverride
+	}
+
 	ssmSession := session.Must(session.NewSession(&aws.Config{
 		Region: aws.String(region),
 	}))


### PR DESCRIPTION
Add a new env var `CHAMBER_AWS_REGION` which can be used to change chamber's region without interfering with the child application's region.

Fixes https://github.com/segmentio/chamber/issues/51