### PR TITLE
Increase DescribeParameters batch size from 10 to 50

### DIFF
--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -267,6 +267,7 @@ func (s *SSMStore) List(service string, includeValues bool) ([]Secret, error) {
 						Values: []*string{aws.String("/" + service)},
 					},
 				},
+				MaxResults: aws.Int64(50),
 				NextToken: nextToken,
 			}
 		} else {
@@ -277,6 +278,7 @@ func (s *SSMStore) List(service string, includeValues bool) ([]Secret, error) {
 						Values: []*string{aws.String(service + ".")},
 					},
 				},
+				MaxResults: aws.Int64(50),
 				NextToken: nextToken,
 			}
 		}


### PR DESCRIPTION
Similarly to https://github.com/segmentio/chamber/issues/34 and https://github.com/segmentio/chamber/pull/36 we ran into rate limiting problems when we started using chamber in production.

Retrying helped, but it does feel like it's a workaround. We wanted to see if we could find a better solution or get our rate limit raised, so we got in touch with AWS support and this is what they suggested.

`DescribeParameters` uses a default batch size of 10, but it can be increased up to 50. AWS support suggested make it 50.

We are currently running a forked version of chamber setting MaxResults to 50 and this seems to have made the problem go away. One of our apps has almost 60 secrets, this change reduced the number of calls to `DescribeParameters` from 6 to 2 (which is a significant change when multiplied by all ECS tasks we run).

Was there any reason you decided to use the default batch size of 10? This could be a configuration parameter if there's any reason one might want to use a smaller batch size. I'm happy to make the change if you think we shouldn't just hardcode it to the maximum allowed value.


