### PR TITLE
 Add export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ that is unneeded. Parameter store automatically versions secrets and passing
 the `--version/-v` flag to read can print older versions of the secret. Default
 version (-1) is the latest secret.
 
+### Exporting
+```bash
+$ chamber export [--format <format>] [--output-file <file>]  <service...>
+{"key","secret"}
+```
+
+`export` providers ability to export secrets in various file formats. The following
+file formats are supported:
+
+* json (default)
+* java-properties
+* csv
+* tsv
+
+File is written to standard output by default but you may specify an output
+file.
 
 ### Deleting
 ```bash

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -12,6 +12,7 @@ import (
 var deleteCmd = &cobra.Command{
 	Use:   "delete <service> <key>",
 	Short: "Delete a secret, including all versions",
+	Args:  cobra.ExactArgs(2),
 	RunE:  delete,
 }
 
@@ -20,13 +21,6 @@ func init() {
 }
 
 func delete(cmd *cobra.Command, args []string) error {
-	if len(args) < 2 {
-		return ErrTooFewArguments
-	}
-	if len(args) > 2 {
-		return ErrTooManyArguments
-	}
-
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -13,14 +13,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	ErrCommandMissing = errors.New("must specify command to run")
-)
-
 // execCmd represents the exec command
 var execCmd = &cobra.Command{
-	Use:   "exec <service...> -- <command>",
+	Use:   "exec <service...> -- <command> [<arg...>]",
 	Short: "Executes a command with secrets loaded into the environment",
+	Args: func(cmd *cobra.Command, args []string) error {
+		dashIx := cmd.ArgsLenAtDash()
+		if dashIx == -1 {
+			return errors.New("please separate services and command with '--'. See usage")
+		}
+		if err := cobra.MinimumNArgs(1)(cmd, args[:dashIx]); err != nil {
+			return errors.Wrap(err, "at least one service must be specified")
+		}
+		if err := cobra.MinimumNArgs(1)(cmd, args[dashIx:]); err != nil {
+			return errors.Wrap(err, "must specify command to run. See usage")
+		}
+		return nil
+	},
 	RunE:  execRun,
 }
 
@@ -30,29 +39,11 @@ func init() {
 
 func execRun(cmd *cobra.Command, args []string) error {
 	dashIx := cmd.ArgsLenAtDash()
-	if dashIx == -1 {
-		return ErrCommandMissing
-	}
-
-	args, commandPart := args[:dashIx], args[dashIx:]
-	if len(args) < 1 {
-		return ErrTooFewArguments
-	}
-
-	if len(commandPart) == 0 {
-		return ErrCommandMissing
-	}
-
-	command := commandPart[0]
-
-	var commandArgs []string
-	if len(commandPart) > 1 {
-		commandArgs = commandPart[1:]
-	}
+	services, command, commandArgs := args[:dashIx], args[dashIx], args[dashIx+1:]
 
 	env := environ(os.Environ())
 	secretStore := store.NewSSMStore(numRetries)
-	for _, service := range args {
+	for _, service := range services {
 		if err := validateService(service); err != nil {
 			return errors.Wrap(err, "Failed to validate service")
 		}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/magiconair/properties"
+	"github.com/pkg/errors"
+	"github.com/segmentio/chamber/store"
+	"github.com/spf13/cobra"
+)
+
+// exportCmd represents the export command
+var (
+	exportFormat string
+	exportOutput string
+
+	exportCmd = &cobra.Command{
+		Use:   "export <service...>",
+		Short: "Exports parameters in the specified format",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  runExport,
+	}
+)
+
+func init() {
+	exportCmd.Flags().StringVarP(&exportFormat, "format", "f", "json", "Output format (json, java-properties, csv, tsv)")
+	exportCmd.Flags().StringVarP(&exportOutput, "output-file", "o", "", "Output file (default is standard output)")
+	RootCmd.AddCommand(exportCmd)
+}
+
+func runExport(cmd *cobra.Command, args []string) error {
+	var err error
+
+	secretStore := store.NewSSMStore(numRetries)
+	params := make(map[string]string)
+	for _, service := range args {
+		if err := validateService(service); err != nil {
+			return errors.Wrapf(err, "Failed to validate service %s", service)
+		}
+
+		secrets, err := secretStore.List(strings.ToLower(service), true)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to list store contents for service %s", service)
+		}
+		for _, secret := range secrets {
+			k := key(secret.Meta.Key)
+			if _, ok := params[k]; ok {
+				fmt.Fprintf(os.Stderr, "warning: parameter %s specified more than once (overriden by service %s)\n", k, service)
+			}
+			params[k] = *secret.Value
+		}
+	}
+
+	file := os.Stdout
+	if exportOutput != "" {
+		if file, err = os.OpenFile(exportOutput, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644); err != nil {
+			return errors.Wrap(err, "Failed to open output file for writing")
+		}
+		defer file.Close()
+		defer file.Sync()
+	}
+	w := bufio.NewWriter(file)
+	defer w.Flush()
+
+	switch strings.ToLower(exportFormat) {
+	case "json":
+		err = exportAsJson(params, w)
+	case "java-properties", "properties":
+		err = exportAsJavaProperties(params, w)
+	case "csv":
+		err = exportAsCsv(params, w)
+	case "tsv":
+		err = exportAsTsv(params, w)
+	default:
+		err = errors.Errorf("Unsupported export format: %s", exportFormat)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "Unable to export parameters")
+	}
+
+	return nil
+}
+
+func exportAsJson(params map[string]string, w io.Writer) error {
+	// JSON like:
+	// {"param1":"value1","param2":"value2"}
+	// NOTE: json encoder does sorting by key
+	return json.NewEncoder(w).Encode(params)
+}
+
+func exportAsJavaProperties(params map[string]string, w io.Writer) error {
+	// Java Properties like:
+	// param1 = value1
+	// param2 = value2
+	// ...
+
+	// Load params
+	p := properties.NewProperties()
+	p.DisableExpansion = true
+	for _, k := range sortedKeys(params) {
+		p.Set(k, params[k])
+	}
+
+	// Java expects properties in ISO-8859-1 by default
+	_, err := p.Write(w, properties.ISO_8859_1)
+	return err
+}
+
+func exportAsCsv(params map[string]string, w io.Writer) error {
+	// CSV (Comma Separated Values) like:
+	// param1,value1
+	// param2,value2
+	csvWriter := csv.NewWriter(w)
+	defer csvWriter.Flush()
+	for _, k := range sortedKeys(params) {
+		if err := csvWriter.Write([]string{k, params[k]}); err != nil {
+			return errors.Wrapf(err, "Failed to write param %s to CSV file", k)
+		}
+	}
+	return nil
+}
+
+func exportAsTsv(params map[string]string, w io.Writer) error {
+	// TSV (Tab Separated Values) like:
+	for _, k := range sortedKeys(params) {
+		if _, err := fmt.Fprintf(w, "%s\t%s\n", k, params[k]); err != nil {
+			return errors.Wrapf(err, "Failed to write param %s to TSV file", k)
+		}
+	}
+	return nil
+}
+
+func sortedKeys(params map[string]string) []string {
+	keys := make([]string, len(params))
+	i := 0
+	for k := range params {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -15,6 +15,7 @@ import (
 var historyCmd = &cobra.Command{
 	Use:   "history <service> <key>",
 	Short: "View the history of a secret",
+	Args:  cobra.ExactArgs(2),
 	RunE:  history,
 }
 
@@ -23,13 +24,6 @@ func init() {
 }
 
 func history(cmd *cobra.Command, args []string) error {
-	if len(args) < 2 {
-		return ErrTooFewArguments
-	}
-	if len(args) > 2 {
-		return ErrTooManyArguments
-	}
-
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -15,6 +15,7 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list <service>",
 	Short: "List the secrets set for a service",
+	Args:  cobra.ExactArgs(1),
 	RunE:  list,
 }
 
@@ -23,13 +24,6 @@ func init() {
 }
 
 func list(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return ErrTooFewArguments
-	}
-	if len(args) > 1 {
-		return ErrTooManyArguments
-	}
-
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -19,6 +19,7 @@ var (
 	readCmd = &cobra.Command{
 		Use:   "read <service> <key>",
 		Short: "Read a specific secret from the parameter store",
+		Args:  cobra.ExactArgs(2),
 		RunE:  read,
 	}
 )
@@ -30,13 +31,6 @@ func init() {
 }
 
 func read(cmd *cobra.Command, args []string) error {
-	if len(args) < 2 {
-		return ErrTooFewArguments
-	}
-	if len(args) > 2 {
-		return ErrTooManyArguments
-	}
-
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -29,7 +30,6 @@ var RootCmd = &cobra.Command{
 	Use:           "chamber",
 	Short:         "CLI for storing secrets",
 	SilenceUsage:  true,
-	SilenceErrors: true,
 }
 
 func init() {
@@ -39,11 +39,9 @@ func init() {
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "chamber error: %s\n", err)
-		switch err {
-		case ErrTooFewArguments, ErrTooManyArguments:
-			RootCmd.Usage()
+	if cmd, err := RootCmd.ExecuteC(); err != nil {
+		if strings.Contains(err.Error(), "arg(s)") || strings.Contains(err.Error(), "usage") {
+			cmd.Usage()
 		}
 		os.Exit(1)
 	}

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -10,15 +10,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	ErrTooManyArguments = errors.New("too many arguments")
-	ErrTooFewArguments  = errors.New("too few arguments")
-)
-
 // writeCmd represents the write command
 var writeCmd = &cobra.Command{
 	Use:   "write <service> <key> <value|->",
 	Short: "write a secret",
+	Args:  cobra.ExactArgs(3),
 	RunE:  write,
 }
 
@@ -27,13 +23,6 @@ func init() {
 }
 
 func write(cmd *cobra.Command, args []string) error {
-	if len(args) < 3 {
-		return ErrTooFewArguments
-	}
-	if len(args) > 3 {
-		return ErrTooManyArguments
-	}
-
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -202,7 +202,7 @@
 			"revisionTime": "2017-03-23T00:38:48Z"
 		},
 		{
-			"checksumSHA1": "9guv02oL7uLkwqQNjJv8AJxWXmQ=",
+			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
 			"path": "github.com/pkg/errors",
 			"revision": "ff09b135c25aae272398c51a07235b90a75aa4f0",
 			"revisionTime": "2017-03-16T20:15:38Z"
@@ -215,10 +215,10 @@
 			"revisionTime": "2016-01-29T19:31:06Z"
 		},
 		{
-			"checksumSHA1": "q4eQ3EqPmvAISYOp3DD/GrccXtY=",
+			"checksumSHA1": "aG5wPXVGAEu90TjPFNZFRtox2Zo=",
 			"path": "github.com/spf13/cobra",
-			"revision": "31694f19adeeaeb0a0e5fe95441b390d757753d2",
-			"revisionTime": "2017-06-21T17:26:46Z"
+			"revision": "ccaecb155a2177302cb56cae929251a256d0f646",
+			"revisionTime": "2017-12-07T07:49:35Z"
 		},
 		{
 			"checksumSHA1": "STxYqRb4gnlSr3mRpT+Igfdz/kM=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -202,6 +202,12 @@
 			"revisionTime": "2017-03-23T00:38:48Z"
 		},
 		{
+			"checksumSHA1": "8ae1DyNE/yY9NvY3PmvtQdLBJnc=",
+			"path": "github.com/magiconair/properties",
+			"revision": "49d762b9817ba1c2e9d0c69183c2b4a8b8f1d934",
+			"revisionTime": "2017-10-31T21:05:36Z"
+		},
+		{
 			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
 			"path": "github.com/pkg/errors",
 			"revision": "ff09b135c25aae272398c51a07235b90a75aa4f0",


### PR DESCRIPTION
It allows to export parameters in various formats. In this comment, the
following formats are supported:

* json
* java-properties (.properties)
* csv
* tsv

Depends on https://github.com/segmentio/chamber/pull/56 (though could be refactored not to depend on it)