### PR TITLE
Allow dots in secret keys.

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -53,8 +53,9 @@ func execRun(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "Failed to list store contents")
 		}
 		for _, secret := range secrets {
-			envVarKey := strings.ToUpper(key(secret.Meta.Key))
+			envVarKey := strings.ToUpper(secret.Id.Key)
 			envVarKey = strings.Replace(envVarKey, "-", "_", -1)
+			envVarKey = strings.Replace(envVarKey, ".", "_", -1)
 
 			if env.IsSet(envVarKey) {
 				fmt.Fprintf(os.Stderr, "warning: overwriting environment variable %s\n", envVarKey)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -50,7 +50,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 			return errors.Wrapf(err, "Failed to list store contents for service %s", service)
 		}
 		for _, secret := range secrets {
-			k := key(secret.Meta.Key)
+			k := secret.Id.Key
 			if _, ok := params[k]; ok {
 				fmt.Fprintf(os.Stderr, "warning: parameter %s specified more than once (overriden by service %s)\n", k, service)
 			}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -50,7 +50,7 @@ func list(cmd *cobra.Command, args []string) error {
 
 	for _, secret := range secrets {
 		fmt.Fprintf(w, "%s\t%d\t%s\t%s",
-			key(secret.Meta.Key),
+			secret.Id.Key,
 			secret.Meta.Version,
 			secret.Meta.Created.Local().Format(ShortTimeFormat),
 			secret.Meta.CreatedBy)
@@ -62,17 +62,4 @@ func list(cmd *cobra.Command, args []string) error {
 
 	w.Flush()
 	return nil
-}
-
-func key(s string) string {
-	_, usePaths := os.LookupEnv("CHAMBER_USE_PATHS")
-	if usePaths {
-		tokens := strings.Split(s, "/")
-		secretKey := tokens[2]
-		return secretKey
-	}
-
-	tokens := strings.Split(s, ".")
-	secretKey := tokens[1]
-	return secretKey
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 // Regex's used to validate service and key names
 var (
-	validKeyFormat     = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
+	validKeyFormat     = regexp.MustCompile(`^[A-Za-z0-9-_.]+$`)
 	validServiceFormat = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
 
 	numRetries int
@@ -56,7 +56,7 @@ func validateService(service string) error {
 
 func validateKey(key string) error {
 	if !validKeyFormat.MatchString(key) {
-		return fmt.Errorf("Failed to validate key name '%s'.  Only alphanumeric, dashes, and underscores are allowed for key names", key)
+		return fmt.Errorf("Failed to validate key name '%s'.  Only alphanumeric, dashes, underscores and dots are allowed for key names", key)
 	}
 	return nil
 }

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -21,11 +21,11 @@ const (
 
 // validPathKeyFormat is the format that is expected for key names inside parameter store
 // when using paths
-var validPathKeyFormat = regexp.MustCompile(`^\/[A-Za-z0-9-_]+\/[A-Za-z0-9-_]+$`)
+var validPathKeyFormat = regexp.MustCompile(`^\/([A-Za-z0-9-_]+)\/([A-Za-z0-9-_.]+)$`)
 
 // validKeyFormat is the format that is expected for key names inside parameter store when
 // not using paths
-var validKeyFormat = regexp.MustCompile(`^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$`)
+var validKeyFormat = regexp.MustCompile(`^([A-Za-z0-9-_]+)\.([A-Za-z0-9-_.]+)$`)
 
 // ensure SSMStore confirms to Store interface
 var _ Store = &SSMStore{}
@@ -160,6 +160,7 @@ func (s *SSMStore) readVersion(id SecretId, version int) (Secret, error) {
 		}
 		if thisVersion == version {
 			return Secret{
+				Id:    id,
 				Value: history.Value,
 				Meta: SecretMetadata{
 					Created:   *history.LastModifiedDate,
@@ -246,6 +247,7 @@ func (s *SSMStore) readLatest(id SecretId) (Secret, error) {
 	secretMeta := parameterMetaToSecretMeta(parameter)
 
 	return Secret{
+		Id:    id,
 		Value: param.Value,
 		Meta:  secretMeta,
 	}, nil
@@ -292,11 +294,13 @@ func (s *SSMStore) List(service string, includeValues bool) ([]Secret, error) {
 		}
 
 		for _, meta := range resp.Parameters {
-			if !s.validateName(*meta.Name) {
+			secretId, ok := s.nameToId(*meta.Name)
+			if !ok {
 				continue
 			}
 			secretMeta := parameterMetaToSecretMeta(meta)
 			secrets[secretMeta.Key] = Secret{
+				Id:    secretId,
 				Value: nil,
 				Meta:  secretMeta,
 			}
@@ -391,11 +395,20 @@ func (s *SSMStore) idToName(id SecretId) string {
 	return fmt.Sprintf("%s.%s", id.Service, id.Key)
 }
 
-func (s *SSMStore) validateName(name string) bool {
+func (s *SSMStore) nameToId(name string) (SecretId, bool) {
+	var m []string
 	if s.usePaths {
-		return validPathKeyFormat.MatchString(name)
+		m = validPathKeyFormat.FindStringSubmatch(name)
+	} else {
+		m = validKeyFormat.FindStringSubmatch(name)
 	}
-	return validKeyFormat.MatchString(name)
+	if m == nil {
+		return SecretId{}, false
+	}
+	return SecretId{
+		Service: m[1],
+		Key:     m[2],
+	}, true
 }
 
 func basePath(key string) string {

--- a/store/store.go
+++ b/store/store.go
@@ -34,6 +34,7 @@ type SecretId struct {
 }
 
 type Secret struct {
+	Id    SecretId
 	Value *string
 	Meta  SecretMetadata
 }


### PR DESCRIPTION
Dot is pretty common in java configuration (property) files. There is no
technical reason why dot should not be allowed. On the other hand,
service names should not be allowed to have dots.

What is more, refactor current key parsing a bit and move it to ssmstore
where it really belong (IMHO).