### PR TITLE
Be flexible with KMS key specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ resource "aws_kms_alias" "parameter_store_alias" {
 ```
 
 If you'd like to use an alternate KMS key to encrypt your secrets, you can set
-the environment variable `CHAMBER_KMS_KEY_ALIAS`.
+the environment variable `CHAMBER_KMS_KEY` to KMS key ID, alias or ARN.
 
 ## Usage
 


### PR DESCRIPTION
AWS KMS API calls accept either KMS key ID (which is UUID), alias or key
ARN. Rename CHAMBER_KMS_KEY_ALIAS env var to CHAMBER_KMS_KEY and accept
all those values. In my opinion, it is conterproductive to limit
application to just KMS alias.

Keep CHAMBER_KMS_KEY_ALIAS env var as fallback for backwards
compatibility.