### PR TITLE
add support for case-sensitivity in secret keys

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -26,7 +26,14 @@ func delete(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
-	key := strings.ToLower(args[1])
+	var key string
+
+	if caseSensitive {
+		key = args[1]
+	} else {
+		key = strings.ToLower(args[1])
+	}
+
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -27,7 +27,7 @@ var execCmd = &cobra.Command{
 		}
 		return nil
 	},
-	RunE:  execRun,
+	RunE: execRun,
 }
 
 func init() {
@@ -50,7 +50,14 @@ func execRun(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "Failed to list store contents")
 		}
 		for _, secret := range secrets {
-			envVarKey := strings.ToUpper(key(secret.Meta.Key))
+			var envVarKey string
+
+			if caseSensitive {
+				envVarKey = key(secret.Meta.Key)
+			} else {
+				envVarKey = strings.ToUpper(key(secret.Meta.Key))
+			}
+
 			envVarKey = strings.Replace(envVarKey, "-", "_", -1)
 
 			if env.IsSet(envVarKey) {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -29,7 +29,14 @@ func history(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
-	key := strings.ToLower(args[1])
+	var key string
+
+	if caseSensitive {
+		key = args[1]
+	} else {
+		key = strings.ToLower(args[1])
+	}
+
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
 	}

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -27,6 +27,7 @@ var (
 func init() {
 	readCmd.Flags().IntVarP(&version, "version", "v", -1, "The version number of the secret. Defaults to latest.")
 	readCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only print the secret")
+
 	RootCmd.AddCommand(readCmd)
 }
 
@@ -36,7 +37,14 @@ func read(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
-	key := strings.ToLower(args[1])
+	var key string
+
+	if caseSensitive {
+		key = args[1]
+	} else {
+		key = strings.ToLower(args[1])
+	}
+
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
 	}

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -27,7 +27,6 @@ var (
 func init() {
 	readCmd.Flags().IntVarP(&version, "version", "v", -1, "The version number of the secret. Defaults to latest.")
 	readCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only print the secret")
-
 	RootCmd.AddCommand(readCmd)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,8 @@ import (
 
 // Regex's used to validate service and key names
 var (
+	caseSensitive bool
+
 	validKeyFormat     = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
 	validServiceFormat = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
 
@@ -27,12 +29,13 @@ const (
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:           "chamber",
-	Short:         "CLI for storing secrets",
-	SilenceUsage:  true,
+	Use:          "chamber",
+	Short:        "CLI for storing secrets",
+	SilenceUsage: true,
 }
 
 func init() {
+	RootCmd.PersistentFlags().BoolVarP(&caseSensitive, "case-sensitive", "c", false, "Use case-sensitive keys")
 	RootCmd.PersistentFlags().IntVarP(&numRetries, "retries", "r", DefaultNumRetries, "For SSM, the number of retries we'll make before giving up")
 }
 

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -34,7 +34,14 @@ func write(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
-	key := strings.ToLower(args[1])
+	var key string
+
+	if caseSensitive {
+		key = args[1]
+	} else {
+		key = strings.ToLower(args[1])
+	}
+
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
 	}


### PR DESCRIPTION
Currently, the keys for secrets are down-cased before storage, and then upcased during the `chamber exec` command.

However, ENVs are case sensitive. When attempting to use chamber in conjunction with Terraform.
 this causes problems since [terraform consumes ENVs in the format TF_VAR_my_variable](https://www.terraform.io/docs/configuration/variables.html).

#21 mentions that the current behaviour is deliberate, however it would be nice (critical?) to have the option to run in case-sensitive mode. IMHO it would be even better for case-sensitive mode to be the default - if you want to export ENVs in uppercase, why not store them in uppercase too?