### PR TITLE
Make the service path support variable depths

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -66,13 +66,12 @@ func list(cmd *cobra.Command, args []string) error {
 
 func key(s string) string {
 	_, usePaths := os.LookupEnv("CHAMBER_USE_PATHS")
+	sep := "."
 	if usePaths {
-		tokens := strings.Split(s, "/")
-		secretKey := tokens[2]
-		return secretKey
+		sep = "/"
 	}
 
-	tokens := strings.Split(s, ".")
-	secretKey := tokens[1]
+	tokens := strings.Split(s, sep)
+	secretKey := tokens[len(tokens)-1]
 	return secretKey
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 // Regex's used to validate service and key names
 var (
 	validKeyFormat     = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
-	validServiceFormat = regexp.MustCompile(`^[A-Za-z0-9-_\/]+$`)
+	validServiceFormat = regexp.MustCompile(`^[A-Za-z0-9-_\/.]+$`)
 
 	numRetries int
 )
@@ -49,7 +49,7 @@ func Execute() {
 
 func validateService(service string) error {
 	if !validServiceFormat.MatchString(service) {
-		return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, and underscores are allowed for service names", service)
+		return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, forwardslases, fullstops and underscores are allowed for service names", service)
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 // Regex's used to validate service and key names
 var (
 	validKeyFormat     = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
-	validServiceFormat = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
+	validServiceFormat = regexp.MustCompile(`^[A-Za-z0-9-_\/]+$`)
 
 	numRetries int
 )
@@ -27,9 +27,9 @@ const (
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:           "chamber",
-	Short:         "CLI for storing secrets",
-	SilenceUsage:  true,
+	Use:          "chamber",
+	Short:        "CLI for storing secrets",
+	SilenceUsage: true,
 }
 
 func init() {

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -21,11 +21,11 @@ const (
 
 // validPathKeyFormat is the format that is expected for key names inside parameter store
 // when using paths
-var validPathKeyFormat = regexp.MustCompile(`^\/[A-Za-z0-9-_]+\/[A-Za-z0-9-_]+$`)
+var validPathKeyFormat = regexp.MustCompile(`^\/[A-Za-z0-9-_/]+$`)
 
 // validKeyFormat is the format that is expected for key names inside parameter store when
 // not using paths
-var validKeyFormat = regexp.MustCompile(`^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$`)
+var validKeyFormat = regexp.MustCompile(`^[A-Za-z0-9-_.]+$`)
 
 // ensure SSMStore confirms to Store interface
 var _ Store = &SSMStore{}
@@ -409,7 +409,8 @@ func basePath(key string) string {
 	if len(pathParts) == 1 {
 		return pathParts[0]
 	}
-	return "/" + pathParts[1]
+	end := len(pathParts) - 1
+	return strings.Join(pathParts[0:end], "/")
 }
 
 func parameterMetaToSecretMeta(p *ssm.ParameterMetadata) SecretMetadata {


### PR DESCRIPTION
This PR makes it possible to have the service have a variable depth for the service (`<path>/<service>`). The default "." separator is also supported

e.g

```
chamber write some/path/to/service mykey myvalue
chamber write some/service myotherkey myothervalue

chamber list some/path/to/service
Key             Version         LastModified    User
mykey    1               01-19 13:34:56  arn:aws:iam::0000000000:user/imjoshholloway

chamber list some/service
Key             Version         LastModified    User
myotherkey    1               01-19 13:34:56  arn:aws:iam::0000000000:user/imjoshholloway

chamber list some
Key             Version         LastModified    User
```

Happy to write some tests if needed but wanted to guage the desire to support this before spending too much time on it.