### PR TITLE
Avoid AWS rate-limits

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -27,7 +27,7 @@ var execCmd = &cobra.Command{
 		}
 		return nil
 	},
-	RunE:  execRun,
+	RunE: execRun,
 }
 
 func init() {
@@ -45,18 +45,18 @@ func execRun(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "Failed to validate service")
 		}
 
-		secrets, err := secretStore.List(strings.ToLower(service), true)
+		rawSecrets, err := secretStore.ListRaw(strings.ToLower(service))
 		if err != nil {
 			return errors.Wrap(err, "Failed to list store contents")
 		}
-		for _, secret := range secrets {
-			envVarKey := strings.ToUpper(key(secret.Meta.Key))
+		for _, rawSecret := range rawSecrets {
+			envVarKey := strings.ToUpper(key(rawSecret.Key))
 			envVarKey = strings.Replace(envVarKey, "-", "_", -1)
 
 			if env.IsSet(envVarKey) {
 				fmt.Fprintf(os.Stderr, "warning: overwriting environment variable %s\n", envVarKey)
 			}
-			env.Set(envVarKey, *secret.Value)
+			env.Set(envVarKey, rawSecret.Value)
 		}
 	}
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -45,16 +45,16 @@ func runExport(cmd *cobra.Command, args []string) error {
 			return errors.Wrapf(err, "Failed to validate service %s", service)
 		}
 
-		secrets, err := secretStore.List(strings.ToLower(service), true)
+		rawSecrets, err := secretStore.ListRaw(strings.ToLower(service))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to list store contents for service %s", service)
 		}
-		for _, secret := range secrets {
-			k := key(secret.Meta.Key)
+		for _, rawSecret := range rawSecrets {
+			k := key(rawSecret.Key)
 			if _, ok := params[k]; ok {
 				fmt.Fprintf(os.Stderr, "warning: parameter %s specified more than once (overriden by service %s)\n", k, service)
 			}
-			params[k] = *secret.Value
+			params[k] = rawSecret.Value
 		}
 	}
 

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -150,6 +150,29 @@ func (m *mockSSMClient) DescribeParameters(i *ssm.DescribeParametersInput) (*ssm
 	}, nil
 }
 
+func (m *mockSSMClient) GetParametersByPath(i *ssm.GetParametersByPathInput) (*ssm.GetParametersByPathOutput, error) {
+	parameters := []*ssm.Parameter{}
+
+	for _, param := range m.parameters {
+		// Match ParameterFilters
+		doesMatchStringFilters, err := matchStringFilters(i.ParameterFilters, param)
+		if err != nil {
+			return &ssm.GetParametersByPathOutput{}, err
+		}
+
+		doesMatchPathFilter := *i.Path == "/" || strings.HasPrefix(*param.meta.Name, *i.Path)
+
+		if doesMatchStringFilters && doesMatchPathFilter {
+			parameters = append(parameters, param.currentParam)
+		}
+	}
+
+	return &ssm.GetParametersByPathOutput{
+		Parameters: parameters,
+		NextToken:  nil,
+	}, nil
+}
+
 func (m *mockSSMClient) DescribeParametersPages(i *ssm.DescribeParametersInput, fn func(*ssm.DescribeParametersOutput, bool) bool) error {
 	o, err := m.DescribeParameters(i)
 	if err != nil {
@@ -232,9 +255,22 @@ func matchStringFilters(filters []*ssm.ParameterStringFilter, param mockParamete
 				return false, errors.New("path filter used on non path value")
 			}
 			compareTo = aws.String("/" + tokens[1] + "/")
-		}
-		if !pathInSlice(compareTo, filter.Values) {
-			return false, nil
+
+			if !pathInSlice(compareTo, filter.Values) {
+				return false, nil
+			}
+
+		case "Name":
+			if *filter.Option == "BeginsWith" {
+				result := false
+				for _, value := range filter.Values {
+					if strings.HasPrefix(*param.meta.Name, *value) {
+						result = true
+					}
+				}
+
+				return result, nil
+			}
 		}
 	}
 	return true, nil
@@ -421,6 +457,44 @@ func TestListRaw(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(s))
 		assert.Equal(t, "match.a", s[0].Key)
+	})
+}
+
+func TestListRawWithPaths(t *testing.T) {
+	mock := &mockSSMClient{parameters: map[string]mockParameter{}}
+	store := NewTestSSMStoreWithPaths(mock)
+
+	secrets := []SecretId{
+		{Service: "test", Key: "a"},
+		{Service: "test", Key: "b"},
+		{Service: "test", Key: "c"},
+	}
+	for _, secret := range secrets {
+		store.Write(secret, "value")
+	}
+
+	t.Run("ListRaw should return all keys and values for a service", func(t *testing.T) {
+		s, err := store.ListRaw("test")
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(s))
+		sort.Sort(ByKeyRaw(s))
+		assert.Equal(t, "/test/a", s[0].Key)
+		assert.Equal(t, "/test/b", s[1].Key)
+		assert.Equal(t, "/test/c", s[2].Key)
+
+		assert.Equal(t, "value", s[0].Value)
+		assert.Equal(t, "value", s[1].Value)
+		assert.Equal(t, "value", s[2].Value)
+	})
+
+	t.Run("List should only return exact matches on service name", func(t *testing.T) {
+		store.Write(SecretId{Service: "match", Key: "a"}, "val")
+		store.Write(SecretId{Service: "matchlonger", Key: "a"}, "val")
+
+		s, err := store.ListRaw("match")
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(s))
+		assert.Equal(t, "/match/a", s[0].Key)
 	})
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -38,6 +38,12 @@ type Secret struct {
 	Meta  SecretMetadata
 }
 
+// A secret without any metadata
+type RawSecret struct {
+	Value string
+	Key   string
+}
+
 type SecretMetadata struct {
 	Created   time.Time
 	CreatedBy string
@@ -56,6 +62,7 @@ type Store interface {
 	Write(id SecretId, value string) error
 	Read(id SecretId, version int) (Secret, error)
 	List(service string, includeValues bool) ([]Secret, error)
+	ListRaw(service string) ([]RawSecret, error)
 	History(id SecretId) ([]ChangeEvent, error)
 	Delete(id SecretId) error
 }


### PR DESCRIPTION
Fix for: https://github.com/segmentio/chamber/issues/76

The SSM DescribeParameters API has very aggressive rate-limits because it's only meant for manual cli-usage. This can lead to significant delays or timeout errors when using chamber exec/export simultaneously in several places (eg. when starting a whole lot of processes in production).

Chamber uses the DescribeParameters API to find parameters by prefix (eg. 'myservice.*') when listing parameters. There's no better API for this in the general case, but if using paths, AWS provides a GetParametersByPath API which is designed for production usage and has much higher rate-limits. Unlike DescribeParameters, GetParametersByPath only returns parameter names and values; it does not include any metadata (eg. createdOn timestamps).

This PR separates the use-cases of listing parameter metadata (just for the list command) and listing parameter values (for exec and export commands). It then utilises the GetParametersByPath API for the values-only commands IFF usePaths is true.

Since the GetParametersByPath API requires a new permission, chamber will now gracefully fall-back to the old DescribeParameters implementation, but it will log a deprecation warning about the need for a new permission.

At StileEducation, we've been using a fork with the GetParametersByPath code for a week or so now with no problems. It's totally eradicated the rate-limiting issues which were previously preventing us from deploying chamber.

This doesn't fix the rate-limiting problem for anyone who's not using paths, but there's no good way to do that with the given AWS APIs. The best option would be to call GetParametersByPath on the path `'/'`, then filter the results locally, but that could be really slow for some use-cases; it's not an obvious win like this change is.

The best long-term solution is probably to move to using paths as the preferred convention, in-line with the design of the AWS APIs.