### PR TITLE
sdk: load config by default

### DIFF
--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -45,9 +45,14 @@ func NewSSMStore(numRetries int) *SSMStore {
 	if regionOverride, ok := os.LookupEnv("CHAMBER_AWS_REGION"); ok {
 		region = aws.String(regionOverride)
 	}
-	ssmSession := session.Must(session.NewSession(&aws.Config{
-		Region: region,
-	}))
+	ssmSession := session.Must(session.NewSessionWithOptions(
+		session.Options{
+			Config: aws.Config{
+				Region: region,
+			},
+			SharedConfigState: session.SharedConfigEnable,
+		},
+	))
 
 	// If region is still not set, attempt to determine it via ec2 metadata API
 	region = nil


### PR DESCRIPTION
Read ~/.aws/config to load region configuration.
This will make chamber behave as documented in README.

Fixes #69