### PR TITLE
Enhancement: Adds a masking feature

### DIFF
--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -349,6 +349,13 @@ func (s *SSMStore) List(service string, includeValues bool) ([]Secret, error) {
 // other meta-data. Uses faster AWS APIs with much higher rate-limits. Suitable for
 // use in production environments.
 func (s *SSMStore) ListRaw(service string) ([]RawSecret, error) {
+	return s.ListRawMask(service, MaskOptions{Enable: false, Pattern: ""})
+}
+
+// ListRawMask lists all secrets keys and values for a given service. Does not include any
+// other meta-data. Uses faster AWS APIs with much higher rate-limits. Suitable for
+// use in production environments.  Masks secrets.
+func (s *SSMStore) ListRawMask(service string, mask MaskOptions) ([]RawSecret, error) {
 	if s.usePaths {
 		secrets := map[string]RawSecret{}
 		var nextToken *string
@@ -357,7 +364,7 @@ func (s *SSMStore) ListRaw(service string) ([]RawSecret, error) {
 				MaxResults:     aws.Int64(10),
 				NextToken:      nextToken,
 				Path:           aws.String("/" + service + "/"),
-				WithDecryption: aws.Bool(true),
+				WithDecryption: aws.Bool(!mask.Enable),
 			}
 
 			resp, err := s.svc.GetParametersByPath(getParametersByPathInput)
@@ -382,13 +389,19 @@ func (s *SSMStore) ListRaw(service string) ([]RawSecret, error) {
 				return nil, err
 			}
 
+			var retVal *string
 			for _, param := range resp.Parameters {
 				if !s.validateName(*param.Name) {
 					continue
 				}
 
+				if *param.Type == ssm.ParameterTypeSecureString && mask.Enable {
+					retVal = aws.String(mask.Pattern)
+				} else {
+					retVal = param.Value
+				}
 				secrets[*param.Name] = RawSecret{
-					Value: *param.Value,
+					Value: *retVal,
 					Key:   *param.Name,
 				}
 			}

--- a/store/store.go
+++ b/store/store.go
@@ -63,6 +63,12 @@ type Store interface {
 	Read(id SecretId, version int) (Secret, error)
 	List(service string, includeValues bool) ([]Secret, error)
 	ListRaw(service string) ([]RawSecret, error)
+	ListRawMask(service string, mask MaskOptions) ([]RawSecret, error)
 	History(id SecretId) ([]ChangeEvent, error)
 	Delete(id SecretId) error
+}
+
+type MaskOptions struct {
+	Enable  bool
+	Pattern string
 }


### PR DESCRIPTION
Here is a feature request in the form of a PR.  One thing I really love about `chamber` is that it will export type=String SSM Parameters along with type=SecureString.  That means I can put application configuration that isn't sensitive into SSM Parameter store next to the secrets I create with chamber.  Then I can use chamber to export them all.

The feature request is based on the fact that chamber will fail completely if any secret in that particular service is encrypted with a KMS key that the user doesn't have permission to use.  Not a problem if you are only using chamber for secrets.  But what if I have a mix of secrets and plain strings.  It would be awesome if QA/Dev or other non-privileged users could use chamber to export the parameters stored using chamber.  With this change, you can add the `-m` flag to effectively not fail when a secret is hit that the user can't decrypt.  It allows the encrypted string to be returned in code and simply masks the output to the user.

I think this will be great for our less privileged users to be able to verify settings in environments using the same tool Admins use to export settings.  I provide an option to customize the masking string.

Thoughts?