### PR TITLE
(WIP) Tag parameters as deleted instead of deleting them

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# CZI - Chamber
+
+This repo is a fork of original Chamber tool ([segmentio/chamber](https://github.com/segmentio/chamber)). THer goal is to add the following functionality:
+* (WIP) Add inheritance. Allow loading multiple parameters for hierarchically named services. For instance, `<project>-<env>-<service>` would load all parameters for the specified project (`<project>`), for the env within the project (`<project>-<env>`) and for the specific service in inverse order of precedence.
+* (WIP) Replace behavior of delete action to tag deleted credentials instead of removing them from parameter store. The goal is to allow recovery in case of misdeletion of credentials.
+* (WIP) Allow reverting parameters to a specific version.
+* (WIP) Fix issues that prevent adding parameters with certain values (e.g. values that start with "--")
+
 # Chamber
 
 Chamber is a tool for managing secrets.  Currently it does so by storing

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -4,19 +4,24 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
+	"github.com/chanzuckerberg/chamber/store"
 	"github.com/spf13/cobra"
 )
 
-// deleteCmd represents the delete command
-var deleteCmd = &cobra.Command{
-	Use:   "delete <service> <key>",
-	Short: "Delete a secret, including all versions",
-	Args:  cobra.ExactArgs(2),
-	RunE:  delete,
-}
+var (
+	force bool
+
+	// deleteCmd represents the delete command
+	deleteCmd = &cobra.Command{
+		Use:   "delete <service> <key>",
+		Short: "Tag a secreted as deleted (it will not be Delete a secret, including all versions",
+		Args:  cobra.ExactArgs(2),
+		RunE:  delete,
+	}
+)
 
 func init() {
+	deleteCmd.Flags().BoolVarP(&force, "force", "f", false, "Actually delete a secret, including all versions (non-reversible).")
 	RootCmd.AddCommand(deleteCmd)
 }
 
@@ -37,5 +42,8 @@ func delete(cmd *cobra.Command, args []string) error {
 		Key:     key,
 	}
 
-	return secretStore.Delete(secretId)
+	if force {
+		return secretStore.Delete(secretId)
+	}
+	return secretStore.TagDeleted(secretId)
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
+	"github.com/chanzuckerberg/chamber/store"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/magiconair/properties"
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
+	"github.com/chanzuckerberg/chamber/store"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -7,7 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
+	"github.com/chanzuckerberg/chamber/store"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
+	"github.com/chanzuckerberg/chamber/store"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,7 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
+	"github.com/chanzuckerberg/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -20,11 +20,13 @@ var listCmd = &cobra.Command{
 }
 
 var (
+	includeDeleted bool
 	withValues bool
 )
 
 func init() {
 	listCmd.Flags().BoolVarP(&withValues, "expand", "e", false, "Expand parameter list with values")
+	listCmd.Flags().BoolVarP(&includeDeleted, "deleted", "d", false, "Include parameters marked as deleted")
 	RootCmd.AddCommand(listCmd)
 }
 
@@ -35,10 +37,12 @@ func list(cmd *cobra.Command, args []string) error {
 	}
 
 	secretStore := store.NewSSMStore(numRetries)
-	secrets, err := secretStore.List(service, withValues)
+	fmt.Printf("Include deleted? %#v\n", includeDeleted)
+	secrets, err := secretStore.List(service, withValues, includeDeleted)
 	if err != nil {
 		return errors.Wrap(err, "Failed to list store contents")
 	}
+	fmt.Printf("Secrets: %#v\n", secrets)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)
 

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -7,7 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
+	"github.com/chanzuckerberg/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -58,12 +58,13 @@ func read(cmd *cobra.Command, args []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)
-	fmt.Fprintln(w, "Key\tValue\tVersion\tLastModified\tUser")
-	fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n",
+	fmt.Fprintln(w, "Key\tValue\tVersion\tLastModified\tDeleted\tUser")
+	fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%t\t%s\n",
 		key,
 		*secret.Value,
 		secret.Meta.Version,
 		secret.Meta.Created.Local().Format(ShortTimeFormat),
+		secret.Deleted,
 		secret.Meta.CreatedBy)
 	w.Flush()
 	return nil

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
+	"github.com/chanzuckerberg/chamber/store"
 	"github.com/spf13/cobra"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/segmentio/chamber/cmd"
+import "github.com/chanzuckerberg/chamber/cmd"
 
 var (
 	// This is updated by linker flags during build

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -149,6 +149,49 @@ func (s *SSMStore) Delete(id SecretId) error {
 	return nil
 }
 
+func (s *SSMStore) TagDeleted(id SecretId) error {
+	tags := []*ssm.Tag{
+		&ssm.Tag{
+			Key: aws.String("Deleted2"),
+			Value: aws.String("true"),
+		},
+	}
+	return s.Tag(id, tags)
+}
+
+// Tag adds tags to a parameter.
+func (s *SSMStore) Tag(id SecretId, tags []*ssm.Tag) error {
+	// first read to ensure parameter present
+	_, err := s.Read(id, -1)
+	if err != nil {
+		return err
+	}
+
+	// list tags for resource
+	listTagsForResourceInput := &ssm.ListTagsForResourceInput{
+		ResourceId: aws.String(s.idToName(id)),
+		ResourceType: aws.String("Parameter"),
+	}
+
+	_, err = s.svc.ListTagsForResource(listTagsForResourceInput)
+	if err != nil {
+		return err
+	}
+
+	addTagsToResourceInput := &ssm.AddTagsToResourceInput{
+		ResourceId: aws.String(s.idToName(id)),
+		ResourceType: aws.String("Parameter"),
+		Tags: tags,
+	}
+
+	_, err = s.svc.AddTagsToResource(addTagsToResourceInput)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s *SSMStore) readVersion(id SecretId, version int) (Secret, error) {
 	getParameterHistoryInput := &ssm.GetParameterHistoryInput{
 		Name:           aws.String(s.idToName(id)),
@@ -158,6 +201,11 @@ func (s *SSMStore) readVersion(id SecretId, version int) (Secret, error) {
 	resp, err := s.svc.GetParameterHistory(getParameterHistoryInput)
 	if err != nil {
 		return Secret{}, ErrSecretNotFound
+	}
+
+	isDeleted, err := s.isDeleted(s.idToName(id))
+	if err != nil {
+		return Secret{}, err
 	}
 
 	for _, history := range resp.Parameters {
@@ -174,6 +222,7 @@ func (s *SSMStore) readVersion(id SecretId, version int) (Secret, error) {
 					Version:   thisVersion,
 					Key:       *history.Name,
 				},
+				Deleted: isDeleted,
 			}, nil
 		}
 	}
@@ -252,16 +301,22 @@ func (s *SSMStore) readLatest(id SecretId) (Secret, error) {
 
 	secretMeta := parameterMetaToSecretMeta(parameter)
 
+	isDeleted, err := s.isDeleted(s.idToName(id))
+	if err != nil {
+		return Secret{}, err
+	}
+
 	return Secret{
 		Value: param.Value,
 		Meta:  secretMeta,
+		Deleted: isDeleted,
 	}, nil
 }
 
 // List lists all secrets for a given service.  If includeValues is true,
 // then those secrets are decrypted and returned, otherwise only the metadata
 // about a secret is returned.
-func (s *SSMStore) List(service string, includeValues bool) ([]Secret, error) {
+func (s *SSMStore) List(service string, includeValues bool, includeDeleted bool) ([]Secret, error) {
 	secrets := map[string]Secret{}
 
 	var nextToken *string
@@ -316,6 +371,19 @@ func (s *SSMStore) List(service string, includeValues bool) ([]Secret, error) {
 		nextToken = resp.NextToken
 	}
 
+	if !includeDeleted {
+		secretKeys := keys(secrets)
+		for _, secretKey := range secretKeys {
+			isDeleted, err := s.isDeleted(secretKey)
+			if err != nil {
+				return nil, err
+			}
+			if isDeleted {
+				delete(secrets, secretKey)
+			}
+		}
+	}
+
 	if includeValues {
 		secretKeys := keys(secrets)
 		for i := 0; i < len(secretKeys); i += 10 {
@@ -354,10 +422,10 @@ func (s *SSMStore) ListRaw(service string) ([]RawSecret, error) {
 		var nextToken *string
 		for {
 			getParametersByPathInput := &ssm.GetParametersByPathInput{
-				MaxResults:     aws.Int64(10),
-				NextToken:      nextToken,
-				Path:           aws.String("/" + service + "/"),
-				WithDecryption: aws.Bool(true),
+				MaxResults:       aws.Int64(10),
+				NextToken:        nextToken,
+				Path:             aws.String("/" + service + "/"),
+				WithDecryption:   aws.Bool(true),
 			}
 
 			resp, err := s.svc.GetParametersByPath(getParametersByPathInput)
@@ -383,7 +451,12 @@ func (s *SSMStore) ListRaw(service string) ([]RawSecret, error) {
 			}
 
 			for _, param := range resp.Parameters {
-				if !s.validateName(*param.Name) {
+				isDeleted, err := s.isDeleted(*param.Name)
+				if err != nil {
+					return nil, err
+				}
+
+				if isDeleted || !s.validateName(*param.Name) {
 					continue
 				}
 
@@ -461,7 +534,7 @@ func (s *SSMStore) History(id SecretId) ([]ChangeEvent, error) {
 
 func (s *SSMStore) listRawViaList(service string) ([]RawSecret, error) {
 	// Delegate to List
-	secrets, err := s.List(service, true)
+	secrets, err := s.List(service, true, false)
 
 	if err != nil {
 		return nil, err
@@ -479,6 +552,26 @@ func (s *SSMStore) listRawViaList(service string) ([]RawSecret, error) {
 	}
 
 	return rawSecrets, nil
+}
+
+func (s *SSMStore) isDeleted(key string) (bool, error) {
+	listTagsForResourceInput := &ssm.ListTagsForResourceInput{
+		ResourceId: aws.String(key),
+		ResourceType: aws.String("Parameter"),
+	}
+
+	resp, err := s.svc.ListTagsForResource(listTagsForResourceInput)
+	if err != nil {
+		return false, err
+	}
+
+	for _, tag := range resp.TagList {
+		key := *tag.Key
+		if (key == "Deleted") {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *SSMStore) idToName(id SecretId) string {

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -386,7 +386,7 @@ func TestList(t *testing.T) {
 	}
 
 	t.Run("List should return all keys for a service", func(t *testing.T) {
-		s, err := store.List("test", false)
+		s, err := store.List("test", false, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(s))
 		sort.Sort(ByKey(s))
@@ -396,7 +396,7 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("List should not return values if includeValues is false", func(t *testing.T) {
-		s, err := store.List("test", false)
+		s, err := store.List("test", false, false)
 		assert.Nil(t, err)
 		for _, secret := range s {
 			assert.Nil(t, secret.Value)
@@ -404,7 +404,7 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("List should return values if includeValues is true", func(t *testing.T) {
-		s, err := store.List("test", true)
+		s, err := store.List("test", true, false)
 		assert.Nil(t, err)
 		for _, secret := range s {
 			assert.Equal(t, "value", *secret.Value)
@@ -415,7 +415,7 @@ func TestList(t *testing.T) {
 		store.Write(SecretId{Service: "match", Key: "a"}, "val")
 		store.Write(SecretId{Service: "matchlonger", Key: "a"}, "val")
 
-		s, err := store.List("match", false)
+		s, err := store.List("match", false, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(s))
 		assert.Equal(t, "match.a", s[0].Meta.Key)
@@ -622,7 +622,7 @@ func TestListPaths(t *testing.T) {
 	}
 
 	t.Run("List should return all keys for a service", func(t *testing.T) {
-		s, err := store.List("test", false)
+		s, err := store.List("test", false, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(s))
 		sort.Sort(ByKey(s))
@@ -632,7 +632,7 @@ func TestListPaths(t *testing.T) {
 	})
 
 	t.Run("List should not return values if includeValues is false", func(t *testing.T) {
-		s, err := store.List("test", false)
+		s, err := store.List("test", false, false)
 		assert.Nil(t, err)
 		for _, secret := range s {
 			assert.Nil(t, secret.Value)
@@ -640,7 +640,7 @@ func TestListPaths(t *testing.T) {
 	})
 
 	t.Run("List should return values if includeValues is true", func(t *testing.T) {
-		s, err := store.List("test", true)
+		s, err := store.List("test", true, false)
 		assert.Nil(t, err)
 		for _, secret := range s {
 			assert.Equal(t, "value", *secret.Value)
@@ -651,7 +651,7 @@ func TestListPaths(t *testing.T) {
 		store.Write(SecretId{Service: "match", Key: "a"}, "val")
 		store.Write(SecretId{Service: "matchlonger", Key: "a"}, "val")
 
-		s, err := store.List("match", false)
+		s, err := store.List("match", false, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(s))
 		assert.Equal(t, "/match/a", s[0].Meta.Key)

--- a/store/store.go
+++ b/store/store.go
@@ -34,8 +34,9 @@ type SecretId struct {
 }
 
 type Secret struct {
-	Value *string
-	Meta  SecretMetadata
+	Value   *string
+	Meta    SecretMetadata
+	Deleted bool  
 }
 
 // A secret without any metadata
@@ -61,7 +62,7 @@ type ChangeEvent struct {
 type Store interface {
 	Write(id SecretId, value string) error
 	Read(id SecretId, version int) (Secret, error)
-	List(service string, includeValues bool) ([]Secret, error)
+	List(service string, includeValues bool, includeDeleted bool) ([]Secret, error)
 	ListRaw(service string) ([]RawSecret, error)
 	History(id SecretId) ([]ChangeEvent, error)
 	Delete(id SecretId) error


### PR DESCRIPTION
TODO: update store test to include ListTagsForResource mock.

- `Delete` command tags resources as delete instead of deleting (Goal: preventing accidental total loss of credentials to resources).
- Added force flag to actually delete the resource (previous default behavior)
- Updated `list`, `exec` and `read` commands to support new delete behavior.