### PR TITLE
Enhancement: Add execlocal command to use a local env file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ environment.
 
 ### Exec Local
 ```bash
-$ chamber execlocal <service...> -- <your executable>
+$ chamber execlocal <file...> -- <your executable>
 ```
 
 `execlocal` populates the environment with the secrets from the specified files

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ example, if you do `chamber exec app apptwo -- ...` and both apps have a secret
 named `api_key`, the `api_key` from `apptwo` will be the one set in your
 environment.
 
+### Exec Local
+```bash
+$ chamber execlocal <service...> -- <your executable>
+```
+
+`execlocal` populates the environment with the secrets from the specified files
+and executes the given command.
+
+Secrets from files are loaded in the order specified in the command.  For
+example, if you do `chamber execlocal .env .env1 -- ...` and both files have a secret
+named `API_KEY`, the `API_KEY` from `.env1` will be the one set in your
+environment.
+
 ### Reading
 ```bash
 $ chamber read service key

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ example, if you do `chamber execlocal .env .env1 -- ...` and both files have a s
 named `API_KEY`, the `API_KEY` from `.env1` will be the one set in your
 environment.
 
+Files should contain environment variables in the following format:
+```bash
+KEY=VALUE
+```
+
 ### Reading
 ```bash
 $ chamber read service key

--- a/cmd/execlocal.go
+++ b/cmd/execlocal.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/chamber/store"
+	"github.com/spf13/cobra"
+)
+
+// execLocalCmd represents the execlocal command
+var execLocalCmd = &cobra.Command{
+	Use:   "execlocal <file...> -- <command> [<arg...>]",
+	Short: "Executes a command with secrets loaded into the environment",
+	Args: func(cmd *cobra.Command, args []string) error {
+		dashIx := cmd.ArgsLenAtDash()
+		if dashIx == -1 {
+			return errors.New("please separate files and command with '--'. See usage")
+		}
+		if err := cobra.MinimumNArgs(1)(cmd, args[:dashIx]); err != nil {
+			return errors.Wrap(err, "at least one file must be specified")
+		}
+		if err := cobra.MinimumNArgs(1)(cmd, args[dashIx:]); err != nil {
+			return errors.Wrap(err, "must specify command to run. See usage")
+		}
+		return nil
+	},
+	RunE: execLocalRun,
+}
+
+func init() {
+	RootCmd.AddCommand(execLocalCmd)
+}
+
+func execLocalRun(cmd *cobra.Command, args []string) error {
+	dashIx := cmd.ArgsLenAtDash()
+	files, command, commandArgs := args[:dashIx], args[dashIx], args[dashIx+1:]
+
+	env := environ(os.Environ())
+	for _, file := range files {
+		if err := validateFile(file); err != nil {
+			return errors.Wrap(err, "Failed to validate file")
+		}
+
+		rawSecrets, err := listRaw(file)
+		if err != nil {
+			return errors.Wrap(err, "Failed to list file contents")
+		}
+		for _, rawSecret := range rawSecrets {
+			if env.IsSet(rawSecret.Key) {
+				fmt.Fprintf(os.Stderr, "warning: overwriting environment variable %s\n", rawSecret.Key)
+			}
+			env.Set(rawSecret.Key, rawSecret.Value)
+		}
+	}
+
+	return exec(command, commandArgs, env)
+}
+
+func listRaw(file string) ([]store.RawSecret, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var secrets []store.RawSecret
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		text := scanner.Text()
+
+		if len(text) == 0 || text[0] == '#' {
+			continue
+		}
+
+		idx := strings.Index(text, "=")
+		if idx <= 0 {
+			fmt.Fprintf(os.Stderr, "warning: invalid line in file \"%s\"\n", text)
+			continue
+		}
+
+		secrets = append(secrets, store.RawSecret{
+			Key:   text[0:idx],
+			Value: text[idx+1:],
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return secrets, nil
+}

--- a/cmd/execlocal.go
+++ b/cmd/execlocal.go
@@ -95,3 +95,8 @@ func listRaw(file string) ([]store.RawSecret, error) {
 
 	return secrets, nil
 }
+
+func validateFile(file string) error {
+	_, err := os.Stat(file)
+	return err
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,3 +62,8 @@ func validateKey(key string) error {
 	}
 	return nil
 }
+
+func validateFile(file string) error {
+	_, err := os.Stat(file)
+	return err
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,8 +62,3 @@ func validateKey(key string) error {
 	}
 	return nil
 }
-
-func validateFile(file string) error {
-	_, err := os.Stat(file)
-	return err
-}


### PR DESCRIPTION
This allows you to use a local env file for development purposes. It works the same way as `exec`, but instead of getting the parameters from AWS Parameter Store, it just reads files in `dotenv` format.