### PR TITLE
S3 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ If you'd like to use a different region for chamber without changing `AWS_REGION
 
 By default, chamber store secrets in AWS Parameter Store.  We now also provide an experimental S3 backend for storing secrets in S3 instead.
 
-To configure chamber to use the S3 backend, set `CHAMBER_SECRET_BACKEND` to `S3`, and `CHAMBER_S3_BUCKET` to an existing S3 bucket (by default, chamber will attempt to use a bucket named `chamber-secrets`).
+To configure chamber to use the S3 backend, set `CHAMBER_SECRET_BACKEND` to `S3`, and `CHAMBER_S3_BUCKET` to an existing S3 bucket.  Preferably, this bucket should reject uploads that do not set the server side encryption header ([see this doc for details how](https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/))
 
 This feature is experimental, and not currently meant for production work.
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ for more details.
 
 If you'd like to use a different region for chamber without changing `AWS_REGION`, you can use `CHAMBER_AWS_REGION` to override just for chamber.
 
+## S3 Backend (experimental)
+
+By default, chamber store secrets in AWS Parameter Store.  We now also provide an experimental S3 backend for storing secrets in S3 instead.
+
+To configure chamber to use the S3 backend, set `CHAMBER_SECRET_BACKEND` to `S3`, and `CHAMBER_S3_BUCKET` to an existing S3 bucket (by default, chamber will attempt to use a bucket named `chamber-secrets`).
+
+This feature is experimental, and not currently meant for production work.
+
 ## Releasing
 
 To cut a new release, just push a tag named `v<semver>` where `<semver>` is a

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -31,7 +31,7 @@ func delete(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := getSecretStore()
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +38,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	services, command, commandArgs := args[:dashIx], args[dashIx], args[dashIx+1:]
 
 	env := environ(os.Environ())
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := getSecretStore()
 	for _, service := range services {
 		if err := validateService(service); err != nil {
 			return errors.Wrap(err, "Failed to validate service")

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/magiconair/properties"
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +37,7 @@ func init() {
 func runExport(cmd *cobra.Command, args []string) error {
 	var err error
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := getSecretStore()
 	params := make(map[string]string)
 	for _, service := range args {
 		if err := validateService(service); err != nil {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -34,7 +34,7 @@ func history(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := getSecretStore()
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -51,7 +51,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to decode input as json")
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := getSecretStore()
 
 	for key, value := range toBeImported {
 		secretId := store.SecretId{

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,7 +7,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,7 @@ func list(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := getSecretStore()
 	secrets, err := secretStore.List(service, withValues)
 	if err != nil {
 		return errors.Wrap(err, "Failed to list store contents")

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -41,7 +41,8 @@ func read(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := getSecretStore()
+
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,33 +74,16 @@ func validateKey(key string) error {
 }
 
 func getSecretStore() store.Store {
-	backend, ok := os.LookupEnv(BackendEnvVar)
-	if !ok {
-		backend = SSMBackend
-	}
+	backend := strings.ToUpper(os.Getenv(BackendEnvVar))
 
-	backend = strings.ToUpper(backend)
-	if !stringInSlice(backend, Backends) {
-		// TODO: warn user
-		backend = SSMBackend
-	}
-
+	var s store.Store
 	switch backend {
-	case SSMBackend:
-		return store.NewSSMStore(numRetries)
 	case S3Backend:
-		return store.NewS3Store(numRetries)
+		s = store.NewS3Store(numRetries)
+	case SSMBackend:
+		fallthrough
+	default:
+		s = store.NewSSMStore(numRetries)
 	}
-
-	// This line is unreachable, but necessary to satisfy the compiler
-	panic("unreachable")
-}
-
-func stringInSlice(v string, sl []string) bool {
-	for _, val := range sl {
-		if v == val {
-			return true
-		}
-	}
-	return false
+	return s
 }

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -58,7 +58,7 @@ func write(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := getSecretStore()
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/store/backendbenchmarks_test.go
+++ b/store/backendbenchmarks_test.go
@@ -1,0 +1,115 @@
+package store
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+// This file contains some tests which can be used to benchmark
+// performance against real AWS API's.  Since this requires provisioned
+// infra and authed AWS user/role, these tests are disabled during automated testing.
+
+// To enable set the testing flag backendbenchmark (go test -benchmark)
+
+const (
+	KeysPerService = 15
+)
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+var benchmarkEnabled bool
+
+func init() {
+	flag.BoolVar(&benchmarkEnabled, "benchmark", false, "run backend benchmarks")
+}
+
+func RandStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func benchmarkStore(t *testing.T, store Store, services []string) {
+	setupStore(t, store, services)
+	defer cleanupStore(t, store, services)
+
+	concurrentExecs := []int{1, 10, 500, 1000}
+
+	for _, concurrency := range concurrentExecs {
+		var wg sync.WaitGroup
+		start := time.Now()
+
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go emulateExec(t, &wg, store, services)
+
+		}
+		wg.Wait()
+		elapsed := time.Now().Sub(start)
+		t.Logf("Concurrently started %d services in %s", concurrency, elapsed)
+	}
+}
+
+func emulateExec(t *testing.T, wg *sync.WaitGroup, s Store, services []string) error {
+	defer wg.Done()
+	// Exec calls ListRaw once per service specified
+	for _, service := range services {
+		_, err := s.ListRaw(service)
+		if err != nil {
+			t.Logf("Failed to execute ListRaw: %s", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func TestS3StoreConcurrency(t *testing.T) {
+	if !benchmarkEnabled {
+		t.SkipNow()
+	}
+	s := NewS3Store(10)
+	benchmarkStore(t, s, []string{"foo"})
+}
+
+func TestSSMConcurrency(t *testing.T) {
+	if !benchmarkEnabled {
+		t.SkipNow()
+	}
+	s := NewSSMStore(10)
+	benchmarkStore(t, s, []string{"foo"})
+}
+
+func setupStore(t *testing.T, store Store, services []string) {
+	// populate the store for services listed
+	for _, service := range services {
+		for i := 0; i < KeysPerService; i++ {
+			key := fmt.Sprintf("var%d", i)
+			id := SecretId{
+				Service: service,
+				Key:     key,
+			}
+
+			store.Write(id, RandStringRunes(100))
+		}
+	}
+}
+
+func cleanupStore(t *testing.T, store Store, services []string) {
+	for _, service := range services {
+		for i := 0; i < KeysPerService; i++ {
+			key := fmt.Sprintf("var%d", i)
+			id := SecretId{
+				Service: service,
+				Key:     key,
+			}
+
+			store.Delete(id)
+		}
+	}
+}

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	DefaultBucket   = "chamber-secrets"
 	MaximumVersions = 100
 	BucketEnvVar    = "CHAMBER_S3_BUCKET"
 
@@ -70,9 +69,10 @@ func NewS3Store(numRetries int) *S3Store {
 		Region:     region,
 	})
 
-	bucket := DefaultBucket
-	if b, ok := os.LookupEnv(BucketEnvVar); ok {
-		bucket = b
+	bucket, ok := os.LookupEnv(BucketEnvVar)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Must set %s for s3 backend\n", BucketEnvVar)
+		os.Exit(1)
 	}
 
 	return &S3Store{

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -1,0 +1,438 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+const (
+	DefaultBucket   = "chamber-secrets"
+	MaximumVersions = 100
+	BucketEnvVar    = "CHAMBER_S3_BUCKET"
+
+	latestObjectName = "__latest.json"
+)
+
+// secretObject is the serialized format for storing secrets
+// as an s3 object
+type secretObject struct {
+	Service string                `json:"service"`
+	Key     string                `json:"key"`
+	Values  map[int]secretVersion `json:"values"`
+}
+
+// secretVersion holds all the metadata for a specific version
+// of a secret
+type secretVersion struct {
+	Created   time.Time `json:"created"`
+	CreatedBy string    `json:"created_by"`
+	Version   int       `json:"version"`
+	Value     string    `json:"value"`
+}
+
+// latest is used to keep a single object in s3 with all of the
+// most recent values for the given service's secrets.  Keeping this
+// in a single s3 object allows us to use a single s3 GetObject
+// for ListRaw (and thus chamber exec).
+type latest struct {
+	Latest map[string]string `json:"latest"`
+}
+
+var _ Store = &S3Store{}
+
+type S3Store struct {
+	svc    s3iface.S3API
+	stsSvc *sts.STS
+	bucket string
+}
+
+func NewS3Store(numRetries int) *S3Store {
+	session, region := getSession(numRetries)
+
+	svc := s3.New(session, &aws.Config{
+		MaxRetries: aws.Int(numRetries),
+		Region:     region,
+	})
+
+	stsSvc := sts.New(session, &aws.Config{
+		MaxRetries: aws.Int(numRetries),
+		Region:     region,
+	})
+
+	bucket := DefaultBucket
+	if b, ok := os.LookupEnv(BucketEnvVar); ok {
+		bucket = b
+	}
+
+	return &S3Store{
+		svc:    svc,
+		stsSvc: stsSvc,
+		bucket: bucket,
+	}
+
+}
+
+func (s *S3Store) Write(id SecretId, value string) error {
+	index, err := s.readLatest(id.Service)
+	if err != nil {
+		return err
+	}
+
+	objPath := getObjectPath(id)
+	existing, ok, err := s.readObjectById(id)
+	if err != nil {
+		return err
+	}
+
+	var obj secretObject
+	if ok {
+		obj = existing
+	} else {
+		obj = secretObject{
+			Service: id.Service,
+			Key:     fmt.Sprintf("/%s/%s", id.Service, id.Key),
+			Values:  map[int]secretVersion{},
+		}
+	}
+
+	thisVersion := getLatestVersion(obj.Values) + 1
+	user, err := s.getCurrentUser()
+	if err != nil {
+		return err
+	}
+	obj.Values[thisVersion] = secretVersion{
+		Version:   thisVersion,
+		Value:     value,
+		Created:   time.Now().UTC(),
+		CreatedBy: user,
+	}
+
+	pruneOldVersions(obj.Values)
+
+	contents, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	putObjectInput := &s3.PutObjectInput{
+		Bucket:               aws.String(s.bucket),
+		ServerSideEncryption: aws.String(s3.ServerSideEncryptionAes256),
+		Key:                  aws.String(objPath),
+		Body:                 bytes.NewReader(contents),
+	}
+
+	_, err = s.svc.PutObject(putObjectInput)
+	if err != nil {
+		// TODO: catch specific awserr
+		return err
+	}
+
+	index.Latest[id.Key] = value
+	return s.writeLatest(id.Service, index)
+}
+
+func (s *S3Store) Read(id SecretId, version int) (Secret, error) {
+	obj, ok, err := s.readObjectById(id)
+	if err != nil {
+		return Secret{}, err
+	}
+
+	if !ok {
+		return Secret{}, ErrSecretNotFound
+	}
+
+	if version == -1 {
+		version = getLatestVersion(obj.Values)
+	}
+	val, ok := obj.Values[version]
+	if !ok {
+		return Secret{}, ErrSecretNotFound
+	}
+
+	return Secret{
+		Value: aws.String(val.Value),
+		Meta: SecretMetadata{
+			Created:   val.Created,
+			CreatedBy: val.CreatedBy,
+			Version:   val.Version,
+			Key:       obj.Key,
+		},
+	}, nil
+}
+
+func (s *S3Store) List(service string, includeValues bool) ([]Secret, error) {
+	index, err := s.readLatest(service)
+	if err != nil {
+		return []Secret{}, err
+	}
+
+	secrets := []Secret{}
+	for key := range index.Latest {
+		obj, ok, err := s.readObjectById(SecretId{Service: service, Key: key})
+		if err != nil {
+			return []Secret{}, err
+		}
+		if !ok {
+			return []Secret{}, ErrSecretNotFound
+		}
+		version := getLatestVersion(obj.Values)
+
+		val, ok := obj.Values[version]
+		if !ok {
+			return []Secret{}, ErrSecretNotFound
+		}
+
+		s := Secret{
+			Meta: SecretMetadata{
+				Created:   val.Created,
+				CreatedBy: val.CreatedBy,
+				Version:   val.Version,
+				Key:       obj.Key,
+			},
+		}
+
+		if includeValues {
+			s.Value = &val.Value
+		}
+		secrets = append(secrets, s)
+
+	}
+
+	return secrets, nil
+}
+
+func (s *S3Store) ListRaw(service string) ([]RawSecret, error) {
+	index, err := s.readLatest(service)
+	if err != nil {
+		return []RawSecret{}, err
+	}
+
+	secrets := []RawSecret{}
+	for key, value := range index.Latest {
+		s := RawSecret{
+			Key:   fmt.Sprintf("/%s/%s", service, key),
+			Value: value,
+		}
+		secrets = append(secrets, s)
+
+	}
+
+	return secrets, nil
+}
+
+func (s *S3Store) History(id SecretId) ([]ChangeEvent, error) {
+	obj, ok, err := s.readObjectById(id)
+	if err != nil {
+		return []ChangeEvent{}, err
+	}
+
+	if !ok {
+		return []ChangeEvent{}, ErrSecretNotFound
+	}
+
+	events := []ChangeEvent{}
+
+	for ix, secretVersion := range obj.Values {
+		events = append(events, ChangeEvent{
+			Type:    getChangeType(ix),
+			Time:    secretVersion.Created,
+			User:    secretVersion.CreatedBy,
+			Version: secretVersion.Version,
+		})
+	}
+
+	// Sort events by version
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Version < events[j].Version
+	})
+	return events, nil
+}
+
+func (s *S3Store) Delete(id SecretId) error {
+	index, err := s.readLatest(id.Service)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := index.Latest[id.Key]; ok {
+		delete(index.Latest, id.Key)
+	}
+
+	if err := s.deleteObjectById(id); err != nil {
+		return err
+	}
+
+	return s.writeLatest(id.Service, index)
+}
+
+// getCurrentUser uses the STS API to get the current caller identity,
+// so that secret value changes can be correctly attributed to the right
+// aws user/role
+func (s *S3Store) getCurrentUser() (string, error) {
+	resp, err := s.stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", err
+	}
+
+	return *resp.Arn, nil
+}
+
+func (s *S3Store) deleteObjectById(id SecretId) error {
+	path := getObjectPath(id)
+	return s.deleteObject(path)
+}
+
+func (s *S3Store) deleteObject(path string) error {
+	deleteObjectInput := &s3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(path),
+	}
+
+	_, err := s.svc.DeleteObject(deleteObjectInput)
+	return err
+}
+
+func (s *S3Store) readObject(path string) (secretObject, bool, error) {
+	getObjectInput := &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(path),
+	}
+
+	resp, err := s.svc.GetObject(getObjectInput)
+	if err != nil {
+		// handle aws errors
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case s3.ErrCodeNoSuchBucket:
+				return secretObject{}, false, err
+			case s3.ErrCodeNoSuchKey:
+				return secretObject{}, false, nil
+			default:
+				return secretObject{}, false, err
+			}
+		}
+		// generic errors
+		return secretObject{}, false, err
+	}
+
+	raw, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return secretObject{}, false, err
+	}
+
+	var obj secretObject
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return secretObject{}, false, err
+	}
+
+	return obj, true, nil
+
+}
+
+func (s *S3Store) readObjectById(id SecretId) (secretObject, bool, error) {
+	path := getObjectPath(id)
+	return s.readObject(path)
+}
+
+func (s *S3Store) puts3raw(path string, contents []byte) error {
+	putObjectInput := &s3.PutObjectInput{
+		Bucket:               aws.String(s.bucket),
+		ServerSideEncryption: aws.String(s3.ServerSideEncryptionAes256),
+		Key:                  aws.String(path),
+		Body:                 bytes.NewReader(contents),
+	}
+
+	_, err := s.svc.PutObject(putObjectInput)
+	return err
+}
+
+func (s *S3Store) readLatest(service string) (latest, error) {
+	path := fmt.Sprintf("%s/%s", service, latestObjectName)
+
+	getObjectInput := &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(path),
+	}
+
+	resp, err := s.svc.GetObject(getObjectInput)
+	if err != nil {
+		return latest{}, err
+	}
+
+	raw, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return latest{}, err
+	}
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == s3.ErrCodeNoSuchKey {
+				// Index doesn't exist yet, return an empty index
+				return latest{Latest: map[string]string{}}, nil
+			}
+		}
+		return latest{}, err
+	}
+
+	var index latest
+	if err := json.Unmarshal(raw, &index); err != nil {
+		return latest{}, err
+	}
+
+	return index, nil
+}
+
+func (s *S3Store) writeLatest(service string, index latest) error {
+	path := fmt.Sprintf("%s/%s", service, latestObjectName)
+
+	raw, err := json.Marshal(index)
+	if err != nil {
+		return err
+	}
+
+	return s.puts3raw(path, raw)
+}
+
+func stringInSlice(val string, sl []string) bool {
+	for _, v := range sl {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}
+
+func getObjectPath(id SecretId) string {
+	return fmt.Sprintf("%s/%s.json", id.Service, id.Key)
+}
+
+func getLatestVersion(m map[int]secretVersion) int {
+	max := 0
+	for k := range m {
+		if k > max {
+			max = k
+		}
+	}
+	return max
+}
+
+func pruneOldVersions(m map[int]secretVersion) {
+	newest := getLatestVersion(m)
+
+	for version := range m {
+		if version < newest-MaximumVersions {
+			delete(m, version)
+		}
+	}
+}

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -367,21 +367,17 @@ func (s *S3Store) readLatest(service string) (latest, error) {
 
 	resp, err := s.svc.GetObject(getObjectInput)
 	if err != nil {
-		return latest{}, err
-	}
-
-	raw, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return latest{}, err
-	}
-
-	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == s3.ErrCodeNoSuchKey {
 				// Index doesn't exist yet, return an empty index
 				return latest{Latest: map[string]string{}}, nil
 			}
 		}
+		return latest{}, err
+	}
+
+	raw, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
 		return latest{}, err
 	}
 

--- a/store/shared.go
+++ b/store/shared.go
@@ -1,0 +1,40 @@
+package store
+
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+const (
+	RegionEnvVar = "CHAMBER_AWS_REGION"
+)
+
+func getSession(numRetries int) (*session.Session, *string) {
+	var region *string
+
+	if regionOverride, ok := os.LookupEnv(RegionEnvVar); ok {
+		region = aws.String(regionOverride)
+	}
+	retSession := session.Must(session.NewSessionWithOptions(
+		session.Options{
+			Config: aws.Config{
+				Region: region,
+			},
+			SharedConfigState: session.SharedConfigEnable,
+		},
+	))
+
+	// If region is still not set, attempt to determine it via ec2 metadata API
+	if aws.StringValue(retSession.Config.Region) == "" {
+		session := session.New()
+		ec2metadataSvc := ec2metadata.New(session)
+		if regionOverride, err := ec2metadataSvc.Region(); err == nil {
+			region = aws.String(regionOverride)
+		}
+	}
+
+	return retSession, region
+}

--- a/store/shared.go
+++ b/store/shared.go
@@ -21,7 +21,8 @@ func getSession(numRetries int) (*session.Session, *string) {
 	retSession := session.Must(session.NewSessionWithOptions(
 		session.Options{
 			Config: aws.Config{
-				Region: region,
+				Region:     region,
+				MaxRetries: aws.Int(numRetries),
 			},
 			SharedConfigState: session.SharedConfigEnable,
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,176 +3,226 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "BAGzIXWxLqZRXtZohIsib8o6XIw=",
+			"checksumSHA1": "o4Kd5PNa6bw7/wOWWKVY7BR0gBY=",
 			"path": "github.com/aws/aws-sdk-go",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "VGCkLl9kLkVD9pLTJMyFMy3C1Lo=",
+			"checksumSHA1": "Nb4M8Xc8+19Dg8GNV1WlzKGx1HQ=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "n98FANpNeRT5kf6pizdpI7nm6Sw=",
+			"checksumSHA1": "EwL79Cq6euk+EV/t/n2E+jzPNmU=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
+			"checksumSHA1": "uEJU4I6dTKaraQKvrljlYKUZwoc=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
+			"checksumSHA1": "vVSUnICaD9IaBQisCfw0n8zLwig=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
+			"checksumSHA1": "925zPp8gtaXi2gkWrgZ1gAA003A=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
+			"checksumSHA1": "JTilCBYWVAfhbKSnrxCNhE8IFns=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
+			"checksumSHA1": "eI5TmiOTCFjEUNvWeceFycs9dRU=",
+			"path": "github.com/aws/aws-sdk-go/aws/csm",
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
+		},
+		{
+			"checksumSHA1": "6DRhqSAN7O45gYfRIpwDeuJE8j8=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
+			"checksumSHA1": "uPkjJo+J10vbEukYYXmf0w7Cn4Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "PQSXZY7ayypkyZm4FlI3m+G+o4k=",
+			"checksumSHA1": "Q1co3y5Y8rRIEjEXEfUZ9SwTmic=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "n/tgGgh0wICYu+VDYSqlsRy4w9s=",
+			"checksumSHA1": "Ia/AZ2fZp7J4lMO6fpkvfLU/HGY=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "SK5Mn4Ga9+equOQTYA1DTSb3LWY=",
+			"checksumSHA1": "zx1mZCdOwgbjBV3jMfb0kyDd//Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "iywvraxbXf3A/FOzFWjKfBBEQRA=",
+			"checksumSHA1": "Dj9WOMBPbboyUJV4GB99PwPcO4g=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
+		},
+		{
+			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
+			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
+		},
+		{
+			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
+			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
+		},
+		{
+			"checksumSHA1": "tQVg7Sz2zv+KkhbiXxPH0mh9spg=",
+			"path": "github.com/aws/aws-sdk-go/internal/sdkuri",
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
+			"checksumSHA1": "ZX5QHZb0PrK4UF45um2kaAEiX+8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
+			"checksumSHA1": "stsUCJVnZ5yMrmzSExbjbYp5tZ8=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream",
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
+		},
+		{
+			"checksumSHA1": "bOQjEfKXaTqe7dZhDDER/wZUzQc=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi",
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
+		},
+		{
+			"checksumSHA1": "CTsp/h3FbFg9QizH4bH1abLwljg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
+			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "Drt1JfLMa0DQEZLWrnMlTWaIcC8=",
+			"checksumSHA1": "+O6A945eTP9plLpkEMZB0lwBAcg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
+			"checksumSHA1": "uRvmEPKcEdv7qc0Ep2zn0E3Xumc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
+			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
+		},
+		{
+			"checksumSHA1": "4dWtH/HkBpS7TnTf21+HOrE1zFc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "jCWrivRK+K+oW2ZW3sJSuBIBNjQ=",
+			"checksumSHA1": "DmKatmbYsvm+MoCP01PCdQ6Y6Tk=",
+			"path": "github.com/aws/aws-sdk-go/service/s3",
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
+		},
+		{
+			"checksumSHA1": "sEjQjy4nIGc5X07ds4TuYkkw6Ro=",
+			"path": "github.com/aws/aws-sdk-go/service/s3/s3iface",
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
+		},
+		{
+			"checksumSHA1": "UfgmCQjT787z6llIfGM9ZHzuydM=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "cAxlijULuvw8KAphHrR1+u3+AM0=",
+			"checksumSHA1": "BSPkU6D191lNsfFEX4u8ddbK3Ww=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm/ssmiface",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
-			"checksumSHA1": "MerduaV3PxtZAWvOGpgoBIglo38=",
+			"checksumSHA1": "UhIVLDgQc19wjrPj8pP7Fu2UwWc=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
-			"revisionTime": "2017-09-06T17:30:17Z"
-		},
-		{
-			"path": "github.com/aws/aws-sdk-go/ssm",
-			"revision": ""
+			"revision": "ddfc3ca419279cf2f67b12719e51fe8500d0029d",
+			"revisionTime": "2018-07-25T21:42:05Z"
 		},
 		{
 			"checksumSHA1": "jqSVRDK7dGg6E/NikVq1Kw6gdbA=",


### PR DESCRIPTION
This PR adds an experimental S3 backend.  We have run into some AWS rate limiting issues around using Parameter Store at scale, even when using the newer GetParameterByPaths API.  For some very high concurrency cases, we want to explore using S3 with server side encryption, and it would be nice if we could continue to use the same chamber interface.

For storage, the S3 backend assumes a single global secrets bucket by AWS account.  The object layout looks like:

```
chamber-secrets
└── service-foo
    ├── bar.json
    ├── baz.json
    └── __latest.json
```

Where `service-foo` is a service with two secrets, `baz` and `bar`.

`__latest.json` is an index of sorts, which keeps the latest values of each secret for the service, but none of the metadata or previous versions.  This file is used by the `ListRaw` implementation to allow `chamber exec` to only use a single S3 GetObject API call.

Each individual secret file (`bar.json` for example) holds metadata about that secret including previous secret values, and is used to power the `List`, `History`, and `Read` APIs.

For IAM permissions, the idea is to configure task roles such that they have read access to only keys in the s3 bucket with prefix matching their service name.

Also included in `store/backendbenchmarks_test.go` are some simple benchmarks which compare concurrent usage performance for the SSMStore and S3Store backends.  These benchmarks are disabled during automated testing because they require infra and authed AWS users/roles.  They can be enabled by passing the `-benchmark` flag to `go test`.