### PR TITLE
Return original error on reading parameter.

### DIFF
--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -181,7 +181,7 @@ func (s *SSMStore) readLatest(id SecretId) (Secret, error) {
 
 	resp, err := s.svc.GetParameters(getParametersInput)
 	if err != nil {
-		return Secret{}, ErrSecretNotFound
+		return Secret{}, err
 	}
 
 	if len(resp.Parameters) == 0 {

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -83,7 +83,7 @@ func (m *mockSSMClient) GetParameters(i *ssm.GetParametersInput) (*ssm.GetParame
 	if len(parameters) == 0 {
 		return &ssm.GetParametersOutput{
 			Parameters: parameters,
-		}, errors.New("parameters not found")
+		}, ErrSecretNotFound
 	}
 
 	return &ssm.GetParametersOutput{


### PR DESCRIPTION
If there's no matching parameter, the api returns an empty list, in which case we return `ErrSecretNotFound`. Otherwise we should return the original error.

[Fixes #104]