### PR TITLE
Add deb/rpm packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,24 @@
 version: 2
 jobs:
-  build:
+  dist:
     docker:
       - image: circleci/golang:1.10
     working_directory: /go/src/github.com/segmentio/chamber
     steps:
       - checkout
       - run:
-          name: Build
+          name: Install nfpm, rpmbuild
           command: |
-            make govendor dist
+            sudo make -f Makefile.release nfpm-debian rpmbuild-debian
+      - run:
+          name: Make distributables
+          command: |
+            make -f Makefile.release dist
       - persist_to_workspace:
           root: .
           paths: ['dist/*']
 
-  release:
+  publish:
     docker:
       - image: circleci/golang:1.10
     working_directory: /go/src/github.com/segmentio/chamber
@@ -24,20 +28,20 @@ jobs:
       - run:
           name: Release
           command: |
-            make release
+            make -f Makefile.release publish
 
 workflows:
   version: 2
-  build-release:
+  dist-publish:
     jobs:
-      - build
-      - release:
+      - dist
+      - publish:
           requires:
-            - build
+            - dist
           filters:
-            # release on branch push event
+            # release on no branch push events
             branches:
               ignore: /.*/
-            # release only on tag push events like vX[.Y.Z...]
+            # release only on tag push events like vX[.Y.Z...][-whatever]
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /v[0-9]+(\.[0-9]+)*(-[a-zA-Z0-9-]+)?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Install nfpm, rpmbuild
           command: |
-            sudo make -f Makefile.release nfpm-debian rpmbuild-debian
+            sudo make -f Makefile.tools nfpm-debian rpmbuild-debian
       - run:
           name: Make distributables
           command: |
@@ -34,12 +34,16 @@ workflows:
   version: 2
   dist-publish:
     jobs:
-      - dist
+      - dist:
+          # needed to ensure dist happens on tag events
+          filters:
+            tags:
+              only: /.*/
       - publish:
           requires:
             - dist
           filters:
-            # release on no branch push events
+            # never publish from a branch event
             branches:
               ignore: /.*/
             # release only on tag push events like vX[.Y.Z...][-whatever]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,16 @@
 version: 2
 jobs:
+  test:
+    docker:
+      - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/segmentio/chamber
+    steps:
+      - checkout
+      - run:
+          name: Test
+          command: |
+            make test
+
   dist:
     docker:
       - image: circleci/golang:1.10
@@ -32,8 +43,9 @@ jobs:
 
 workflows:
   version: 2
-  dist-publish:
+  test-dist-publish:
     jobs:
+      - test
       - dist:
           # needed to ensure dist happens on tag events
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,16 @@ jobs:
       - checkout
       - attach_workspace: { at: . }
       - run:
+          name: Install tools
+          command: |
+            make -f Makefile.tools github-release
+            # this is all for package_cloud :/
+            sudo apt update -q 
+            sudo apt install -yq ruby ruby-dev build-essential
+            # fixes https://askubuntu.com/questions/872399/error-failed-to-build-gem-native-extension-when-trying-to-download-rubocop
+            sudo gem install rake
+            sudo make -f Makefile.tools package_cloud
+      - run:
           name: Release
           command: |
             make -f Makefile.release publish

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sw[a-z]
 vendor/*/
 dist/
+packagecloud.conf.json

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ clean:
 dist/:
 	mkdir -p dist
 
-dist/chamber-$(VERSION)-darwin-amd64: dist/ govendor
+dist/chamber-$(VERSION)-darwin-amd64: | govendor dist/
 	govendor sync
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o $@
 
-dist/chamber-$(VERSION)-linux-amd64: dist/ govendor
+dist/chamber-$(VERSION)-linux-amd64: | govendor dist/
 	govendor sync
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -1,83 +1,19 @@
+# Goals:
+# - user can build binaries on their system without having to install special tools
+# - user can fork the canonical repo and expect to be able to run CircleCI checks
+#
+# This makefile is meant for humans
+
 VERSION := $(shell git describe --tags --always --dirty="-dev")
 LDFLAGS := -ldflags='-X "main.Version=$(VERSION)"'
-# set --pre-release if not tagged or tree is dirty or there's a `-` in the tag
-ifneq (,$(findstring -,$(VERSION)))
-	GITHUB_RELEASE_FLAGS := "--pre-release"
-endif
 
 all: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64
-
-release: gh-release
-	github-release release \
-	--security-token $$GH_LOGIN \
-	--user segmentio \
-	--repo chamber \
-	$(GITHUB_RELEASE_FLAGS) \
-	--tag $(VERSION) \
-	--name $(VERSION)
-
-publish: publish-github
-
-publish-github: publish-github-darwin publish-github-linux publish-github-deb publish-github-rpm
-
-publish-github-darwin: dist/chamber-$(VERSION)-darwin-amd64 release
-	github-release upload \
-	--security-token $$GH_LOGIN \
-	--user segmentio \
-	--repo chamber \
-	--tag $(VERSION) \
-	--name chamber-$(VERSION)-darwin-amd64 \
-	--file $<
-
-publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 release
-	github-release upload \
-	--security-token $$GH_LOGIN \
-	--user segmentio \
-	--repo chamber \
-	--tag $(VERSION) \
-	--name chamber-$(VERSION)-linux-amd64 \
-	--file $<
-
-publish-github-deb: dist/chamber_$(VERSION)_amd64.deb release
-	github-release upload \
-	--security-token $$GH_LOGIN \
-	--user segmentio \
-	--repo chamber \
-	--tag $(VERSION) \
-	--name chamber_$(VERSION)_amd64.deb \
-	--file $<
-
-publish-github-rpm: dist/chamber_$(VERSION)_amd64.rpm release
-	github-release upload \
-	--security-token $$GH_LOGIN \
-	--user segmentio \
-	--repo chamber \
-	--tag $(VERSION) \
-	--name chamber_$(VERSION)_amd64.rpm \
-	--file $<
-
-	github-release upload \
-	--security-token $$GH_LOGIN \
-	--user segmentio \
-	--repo chamber \
-	--tag $(VERSION) \
-	--name chamber-$(VERSION).sha256sums \
-	--file dist/chamber-$(VERSION).sha256sums
 
 clean:
 	rm -rf ./dist
 
-dist: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm
-	@which sha256sum 2>&1 > /dev/null || ( \
-		echo 'missing sha256sum; install on MacOS with `brew install coreutils && ln -s $$(which gsha256sum) /usr/local/bin/sha256sum`' ; \
-		exit 1; \
-	)
-	cd dist && \
-		sha256sum chamber-$(VERSION)-* > chamber-$(VERSION).sha256sums
-
 dist/:
 	mkdir -p dist
-	
 
 dist/chamber-$(VERSION)-darwin-amd64: dist/ govendor
 	govendor sync
@@ -87,19 +23,7 @@ dist/chamber-$(VERSION)-linux-amd64: dist/ govendor
 	govendor sync
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o $@
 
-dist/nfpm-$(VERSION).yaml: dist/
-	sed -e "s/\$${VERSION}/$(VERSION)/g" -e "s|\$${DIST_BIN}|dist/chamber-$(VERSION)-linux-amd64|g"  < nfpm.yaml.tmpl > $@
-
-dist/chamber_$(VERSION)_amd64.deb: dist/nfpm-$(VERSION).yaml
-	nfpm -f $^ pkg --target $@
-
-dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml
-	nfpm -f $^ pkg --target $@
-
-gh-release:
-	go get -u github.com/aktau/github-release
-
 govendor:
 	go get -u github.com/kardianos/govendor
 
-.PHONY: clean gh-release govendor publish-github publish-github-linux publish-github-rpm publish-github-deb publish-github-darwin release all
+.PHONY: clean all govendor

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@
 VERSION := $(shell git describe --tags --always --dirty="-dev")
 LDFLAGS := -ldflags='-X "main.Version=$(VERSION)"'
 
+test: | govendor
+	govendor sync
+	go test -v ./...
+
 all: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,60 @@
 VERSION := $(shell git describe --tags --always --dirty="-dev")
 LDFLAGS := -ldflags='-X "main.Version=$(VERSION)"'
+# set --pre-release if not tagged or tree is dirty or there's a `-` in the tag
+ifneq (,$(findstring -,$(VERSION)))
+	GITHUB_RELEASE_FLAGS := "--pre-release"
+endif
 
-release: gh-release clean dist
-	govendor sync
+all: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64
+
+release: gh-release
 	github-release release \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
 	--repo chamber \
+	$(GITHUB_RELEASE_FLAGS) \
 	--tag $(VERSION) \
 	--name $(VERSION)
 
+publish: publish-github
+
+publish-github: publish-github-darwin publish-github-linux publish-github-deb publish-github-rpm
+
+publish-github-darwin: dist/chamber-$(VERSION)-darwin-amd64 release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
 	--repo chamber \
 	--tag $(VERSION) \
 	--name chamber-$(VERSION)-darwin-amd64 \
-	--file dist/chamber-$(VERSION)-darwin-amd64
+	--file $<
 
+publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
 	--repo chamber \
 	--tag $(VERSION) \
 	--name chamber-$(VERSION)-linux-amd64 \
-	--file dist/chamber-$(VERSION)-linux-amd64
+	--file $<
+
+publish-github-deb: dist/chamber_$(VERSION)_amd64.deb release
+	github-release upload \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo chamber \
+	--tag $(VERSION) \
+	--name chamber_$(VERSION)_amd64.deb \
+	--file $<
+
+publish-github-rpm: dist/chamber_$(VERSION)_amd64.rpm release
+	github-release upload \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo chamber \
+	--tag $(VERSION) \
+	--name chamber_$(VERSION)_amd64.rpm \
+	--file $<
 
 	github-release upload \
 	--security-token $$GH_LOGIN \
@@ -37,11 +67,7 @@ release: gh-release clean dist
 clean:
 	rm -rf ./dist
 
-dist:
-	mkdir dist
-	govendor sync
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/chamber-$(VERSION)-darwin-amd64
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/chamber-$(VERSION)-linux-amd64
+dist: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm
 	@which sha256sum 2>&1 > /dev/null || ( \
 		echo 'missing sha256sum; install on MacOS with `brew install coreutils && ln -s $$(which gsha256sum) /usr/local/bin/sha256sum`' ; \
 		exit 1; \
@@ -49,8 +75,31 @@ dist:
 	cd dist && \
 		sha256sum chamber-$(VERSION)-* > chamber-$(VERSION).sha256sums
 
+dist/:
+	mkdir -p dist
+	
+
+dist/chamber-$(VERSION)-darwin-amd64: dist/ govendor
+	govendor sync
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o $@
+
+dist/chamber-$(VERSION)-linux-amd64: dist/ govendor
+	govendor sync
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o $@
+
+dist/nfpm-$(VERSION).yaml: dist/
+	sed -e "s/\$${VERSION}/$(VERSION)/g" -e "s|\$${DIST_BIN}|dist/chamber-$(VERSION)-linux-amd64|g"  < nfpm.yaml.tmpl > $@
+
+dist/chamber_$(VERSION)_amd64.deb: dist/nfpm-$(VERSION).yaml
+	nfpm -f $^ pkg --target $@
+
+dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml
+	nfpm -f $^ pkg --target $@
+
 gh-release:
 	go get -u github.com/aktau/github-release
 
 govendor:
 	go get -u github.com/kardianos/govendor
+
+.PHONY: clean gh-release govendor publish-github publish-github-linux publish-github-rpm publish-github-deb publish-github-darwin release all

--- a/Makefile.release
+++ b/Makefile.release
@@ -12,7 +12,10 @@ ifneq (,$(findstring -,$(VERSION)))
 endif
 
 PACKAGECLOUD_DEB_DISTROS := \
-	debian/stretch
+	debian/stretch \
+	ubuntu/trusty \
+	ubuntu/xenial \
+	ubuntu/bionic
 
 PACKAGECLOUD_RPM_DISTROS := \
 	fedora/27 \

--- a/Makefile.release
+++ b/Makefile.release
@@ -11,6 +11,13 @@ ifneq (,$(findstring -,$(VERSION)))
 	PACKAGECLOUD_NAME_SUFFIX := "-prerelease"
 endif
 
+PACKAGECLOUD_DEB_DISTROS := \
+	debian/stretch
+
+PACKAGECLOUD_RPM_DISTROS := \
+	fedora/27 \
+	fedora/28
+
 publish: publish-github publish-packagecloud
 
 publish-github: publish-github-darwin publish-github-linux publish-github-deb publish-github-rpm publish-github-sha256sums
@@ -74,14 +81,19 @@ publish-github-sha256sums: dist/chamber-$(VERSION).sha256sums | github-release
 packagecloud.conf.json:
 	@echo "{\"url\":\"https://packagecloud.io\",\"token\":\"$${PACKAGECLOUD_TOKEN}\"}" > $@
 
+# package_cloud prints the last 4 chars of our token :(
+# so we attempt to filter that out
+
 publish-packagecloud-deb: dist/chamber_$(VERSION)_amd64.deb packagecloud.conf.json
-	@for v in debian/stretch; do \
-		package_cloud push --config packagecloud.conf.json segment/chamber$(PACKAGECLOUD_NAME_SUFFIX)/$$v $< ; \
+	@for v in $(PACKAGECLOUD_DEB_DISTROS); do \
+		package_cloud push --config packagecloud.conf.json segment/chamber$(PACKAGECLOUD_NAME_SUFFIX)/$$v $< | \
+			grep -v 'with token:' ; \
 	done
 
 publish-packagecloud-rpm: dist/chamber_$(VERSION)_amd64.rpm packagecloud.conf.json
-	@for v in fedora/27 fedora/28; do \
-		package_cloud push --config packagecloud.conf.json segment/chamber$(PACKAGECLOUD_NAME_SUFFIX)/$$v $< ; \
+	@for v in $(PACKAGECLOUD_RPM_DISTROS); do \
+		package_cloud push --config packagecloud.conf.json segment/chamber$(PACKAGECLOUD_NAME_SUFFIX)/$$v $< | \
+			grep -v 'with token:' ; \
 	done
 
 dist: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm dist/chamber-$(VERSION).sha256sums

--- a/Makefile.release
+++ b/Makefile.release
@@ -1,0 +1,144 @@
+# Goals:
+# - Linux releases can be published to Github automatically by CircleCI
+#
+# This Makefile is meant for machines
+
+include Makefile
+
+# set --pre-release if not tagged or tree is dirty or there's a `-` in the tag
+ifneq (,$(findstring -,$(VERSION)))
+	GITHUB_RELEASE_FLAGS := "--pre-release"
+endif
+
+publish: publish-github
+
+publish-github: publish-github-darwin publish-github-linux publish-github-deb publish-github-rpm
+
+release: gh-release
+	github-release release \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo chamber \
+	$(GITHUB_RELEASE_FLAGS) \
+	--tag $(VERSION) \
+	--name $(VERSION)
+
+publish-github-darwin: dist/chamber-$(VERSION)-darwin-amd64 release
+	github-release upload \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo chamber \
+	--tag $(VERSION) \
+	--name chamber-$(VERSION)-darwin-amd64 \
+	--file $<
+
+publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 release
+	github-release upload \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo chamber \
+	--tag $(VERSION) \
+	--name chamber-$(VERSION)-linux-amd64 \
+	--file $<
+
+publish-github-deb: dist/chamber_$(VERSION)_amd64.deb release
+	github-release upload \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo chamber \
+	--tag $(VERSION) \
+	--name chamber_$(VERSION)_amd64.deb \
+	--file $<
+
+publish-github-rpm: dist/chamber_$(VERSION)_amd64.rpm release
+	github-release upload \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo chamber \
+	--tag $(VERSION) \
+	--name chamber_$(VERSION)_amd64.rpm \
+	--file $<
+	
+	github-release upload \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo chamber \
+	--tag $(VERSION) \
+	--name chamber-$(VERSION).sha256sums \
+	--file dist/chamber-$(VERSION).sha256sums
+
+dist: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm dist/chamber-$(VERSION).sha256sums
+
+dist/chamber-$(VERSION).sha256sums: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm
+	sha256sum $^ | sed 's|dist/||g' > $@
+
+dist/nfpm-$(VERSION).yaml: dist/
+	sed -e "s/\$${VERSION}/$(VERSION)/g" -e "s|\$${DIST_BIN}|dist/chamber-$(VERSION)-linux-amd64|g" < nfpm.yaml.tmpl > $@
+
+dist/chamber_$(VERSION)_amd64.deb: dist/nfpm-$(VERSION).yaml nfpm
+	nfpm -f $< pkg --target $@
+
+dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml nfpm rpmbuild
+	nfpm -f $< pkg --target $@
+
+gh-release:
+	go get -u github.com/aktau/github-release
+
+
+nfpm:
+	@if ! which nfpm 2>&1 >/dev/null ; then \
+		echo 'missing nfpm; see Makefile.release for recipes' && \
+		exit 1; \
+	fi
+
+sha256sum:
+	@if ! which sha256sum 2>&1 >/dev/null ; then \
+		echo 'missing sha256sum; see Makefile.release for recipes' && \
+		exit 1; \
+	fi
+
+rpmbuild:
+	@if ! which rpmbuild 2>&1 >/dev/null ; then \
+		echo 'missing rpmbuild; see Makefile.release for recipes' && \
+		exit 1; \
+	fi
+
+NFPM_VERSION := 0.9.3
+#from https://github.com/goreleaser/nfpm/releases/download/v0.9.3/nfpm_0.9.3_checksums.txt
+NFPM_SHA256 := f875ac060a30ec5c164e5444a7278322b276707493fa0ced6bfdd56640f0a6ea
+
+# Tools installation recipes
+#
+# These are fragile, non-portable, and often require root
+#
+nfpm-debian:
+	cd /tmp && \
+		curl -Ls https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz > nfpm.tar.gz && \
+		echo "${NFPM_SHA256}  nfpm.tar.gz" | \
+		sha256sum -c && \
+		tar xzvf nfpm.tar.gz && \
+		mv nfpm /usr/local/bin
+
+rpmbuild-debian:
+	apt update -q && apt install rpm -yq
+
+rpmbuild-darwin:
+	brew install rpm
+
+sha256sum-darwin:
+	brew install coreutils && ln -s $$(which gsha256sum) /usr/local/bin/sha256sum`
+
+.PHONY: \
+	gh-release \
+	publish-github \
+	publish-github-linux \
+	publish-github-rpm \
+	publish-github-deb \
+	publish-github-darwin \
+	release \
+	nfpm \
+	sha256sum \
+	nfpm-debian \
+	rpmbuild-debian \
+	rpmbuild-darwin \
+	sha256sum-darwin

--- a/Makefile.release
+++ b/Makefile.release
@@ -8,6 +8,7 @@ include Makefile
 # set --pre-release if not tagged or tree is dirty or there's a `-` in the tag
 ifneq (,$(findstring -,$(VERSION)))
 	GITHUB_RELEASE_FLAGS := "--pre-release"
+	PACKAGECLOUD_NAME_SUFFIX := "-prerelease"
 endif
 
 publish: publish-github publish-packagecloud
@@ -73,14 +74,14 @@ publish-github-sha256sums: dist/chamber-$(VERSION).sha256sums | github-release
 packagecloud.conf.json:
 	@echo "{\"url\":\"https://packagecloud.io\",\"token\":\"$${PACKAGECLOUD_TOKEN}\"}" > $@
 
-publish-packagecloud-deb: dist/chamber_$(VERSION)_amd64.deb
-	@for v in (stretch); do \
-		package_cloud push --config packagecloud.conf.json segment/chamber/debian/$$v $< ; \
+publish-packagecloud-deb: dist/chamber_$(VERSION)_amd64.deb packagecloud.conf.json
+	@for v in debian/stretch; do \
+		package_cloud push --config packagecloud.conf.json segment/chamber$(PACKAGECLOUD_NAME_SUFFIX)/$$v $< ; \
 	done
 
 publish-packagecloud-rpm: dist/chamber_$(VERSION)_amd64.rpm packagecloud.conf.json
-	@for v in `seq 27 29`; do \
-		package_cloud push --config packagecloud.conf.json segment/chamber/fedora/$$v $< ; \
+	@for v in fedora/27 fedora/28; do \
+		package_cloud push --config packagecloud.conf.json segment/chamber$(PACKAGECLOUD_NAME_SUFFIX)/$$v $< ; \
 	done
 
 dist: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm dist/chamber-$(VERSION).sha256sums
@@ -91,10 +92,10 @@ dist/chamber-$(VERSION).sha256sums: dist/chamber-$(VERSION)-darwin-amd64 dist/ch
 dist/nfpm-$(VERSION).yaml: | dist/
 	sed -e "s/\$${VERSION}/$(VERSION)/g" -e "s|\$${DIST_BIN}|dist/chamber-$(VERSION)-linux-amd64|g" < nfpm.yaml.tmpl > $@
 
-dist/chamber_$(VERSION)_amd64.deb: dist/nfpm-$(VERSION).yaml
+dist/chamber_$(VERSION)_amd64.deb: dist/nfpm-$(VERSION).yaml dist/chamber-$(VERSION)-linux-amd64
 	nfpm -f $< pkg --target $@
 
-dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml
+dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml dist/chamber-$(VERSION)-linux-amd64
 	nfpm -f $< pkg --target $@
 
 .PHONY: \

--- a/Makefile.release
+++ b/Makefile.release
@@ -14,7 +14,7 @@ publish: publish-github
 
 publish-github: publish-github-darwin publish-github-linux publish-github-deb publish-github-rpm publish-github-sha256sums
 
-release: | gh-release
+github-release:
 	github-release release \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -23,7 +23,7 @@ release: | gh-release
 	--tag $(VERSION) \
 	--name $(VERSION)
 
-publish-github-darwin: dist/chamber-$(VERSION)-darwin-amd64 | release
+publish-github-darwin: dist/chamber-$(VERSION)-darwin-amd64 | github-release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -32,7 +32,7 @@ publish-github-darwin: dist/chamber-$(VERSION)-darwin-amd64 | release
 	--name chamber-$(VERSION)-darwin-amd64 \
 	--file $<
 
-publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 | release
+publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 | github-release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -41,7 +41,7 @@ publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 | release
 	--name chamber-$(VERSION)-linux-amd64 \
 	--file $<
 
-publish-github-deb: dist/chamber_$(VERSION)_amd64.deb | release
+publish-github-deb: dist/chamber_$(VERSION)_amd64.deb | github-release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -50,7 +50,7 @@ publish-github-deb: dist/chamber_$(VERSION)_amd64.deb | release
 	--name chamber_$(VERSION)_amd64.deb \
 	--file $<
 
-publish-github-rpm: dist/chamber_$(VERSION)_amd64.rpm | release
+publish-github-rpm: dist/chamber_$(VERSION)_amd64.rpm | github-release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -59,7 +59,7 @@ publish-github-rpm: dist/chamber_$(VERSION)_amd64.rpm | release
 	--name chamber_$(VERSION)_amd64.rpm \
 	--file $<
 	
-publish-github-sha256sums: dist/chamber-$(VERSION).sha256sums | release
+publish-github-sha256sums: dist/chamber-$(VERSION).sha256sums | github-release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -82,14 +82,10 @@ dist/chamber_$(VERSION)_amd64.deb: dist/nfpm-$(VERSION).yaml
 dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml
 	nfpm -f $< pkg --target $@
 
-gh-release:
-	go get -u github.com/aktau/github-release
-
 .PHONY: \
-	gh-release \
 	publish-github \
 	publish-github-linux \
 	publish-github-rpm \
 	publish-github-deb \
 	publish-github-darwin \
-	release
+	github-release

--- a/Makefile.release
+++ b/Makefile.release
@@ -10,9 +10,11 @@ ifneq (,$(findstring -,$(VERSION)))
 	GITHUB_RELEASE_FLAGS := "--pre-release"
 endif
 
-publish: publish-github
+publish: publish-github publish-packagecloud
 
 publish-github: publish-github-darwin publish-github-linux publish-github-deb publish-github-rpm publish-github-sha256sums
+
+publish-packagecloud: publish-packagecloud-deb publish-packagecloud-rpm
 
 github-release:
 	github-release release \
@@ -67,6 +69,19 @@ publish-github-sha256sums: dist/chamber-$(VERSION).sha256sums | github-release
 	--tag $(VERSION) \
 	--name chamber-$(VERSION).sha256sums \
 	--file dist/chamber-$(VERSION).sha256sums
+
+packagecloud.conf.json:
+	@echo "{\"url\":\"https://packagecloud.io\",\"token\":\"$${PACKAGECLOUD_TOKEN}\"}" > $@
+
+publish-packagecloud-deb: dist/chamber_$(VERSION)_amd64.deb
+	@for v in (stretch); do \
+		package_cloud push --config packagecloud.conf.json segment/chamber/debian/$$v $< ; \
+	done
+
+publish-packagecloud-rpm: dist/chamber_$(VERSION)_amd64.rpm packagecloud.conf.json
+	@for v in `seq 27 29`; do \
+		package_cloud push --config packagecloud.conf.json segment/chamber/fedora/$$v $< ; \
+	done
 
 dist: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm dist/chamber-$(VERSION).sha256sums
 

--- a/Makefile.release
+++ b/Makefile.release
@@ -12,9 +12,9 @@ endif
 
 publish: publish-github
 
-publish-github: publish-github-darwin publish-github-linux publish-github-deb publish-github-rpm
+publish-github: publish-github-darwin publish-github-linux publish-github-deb publish-github-rpm publish-github-sha256sums
 
-release: gh-release
+release: | gh-release
 	github-release release \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -23,7 +23,7 @@ release: gh-release
 	--tag $(VERSION) \
 	--name $(VERSION)
 
-publish-github-darwin: dist/chamber-$(VERSION)-darwin-amd64 release
+publish-github-darwin: dist/chamber-$(VERSION)-darwin-amd64 | release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -32,7 +32,7 @@ publish-github-darwin: dist/chamber-$(VERSION)-darwin-amd64 release
 	--name chamber-$(VERSION)-darwin-amd64 \
 	--file $<
 
-publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 release
+publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 | release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -41,7 +41,7 @@ publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 release
 	--name chamber-$(VERSION)-linux-amd64 \
 	--file $<
 
-publish-github-deb: dist/chamber_$(VERSION)_amd64.deb release
+publish-github-deb: dist/chamber_$(VERSION)_amd64.deb | release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -50,7 +50,7 @@ publish-github-deb: dist/chamber_$(VERSION)_amd64.deb release
 	--name chamber_$(VERSION)_amd64.deb \
 	--file $<
 
-publish-github-rpm: dist/chamber_$(VERSION)_amd64.rpm release
+publish-github-rpm: dist/chamber_$(VERSION)_amd64.rpm | release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -59,6 +59,7 @@ publish-github-rpm: dist/chamber_$(VERSION)_amd64.rpm release
 	--name chamber_$(VERSION)_amd64.rpm \
 	--file $<
 	
+publish-github-sha256sums: dist/chamber-$(VERSION).sha256sums | release
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -72,61 +73,17 @@ dist: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 d
 dist/chamber-$(VERSION).sha256sums: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm
 	sha256sum $^ | sed 's|dist/||g' > $@
 
-dist/nfpm-$(VERSION).yaml: dist/
+dist/nfpm-$(VERSION).yaml: | dist/
 	sed -e "s/\$${VERSION}/$(VERSION)/g" -e "s|\$${DIST_BIN}|dist/chamber-$(VERSION)-linux-amd64|g" < nfpm.yaml.tmpl > $@
 
-dist/chamber_$(VERSION)_amd64.deb: dist/nfpm-$(VERSION).yaml nfpm
+dist/chamber_$(VERSION)_amd64.deb: dist/nfpm-$(VERSION).yaml
 	nfpm -f $< pkg --target $@
 
-dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml nfpm rpmbuild
+dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml
 	nfpm -f $< pkg --target $@
 
 gh-release:
 	go get -u github.com/aktau/github-release
-
-
-nfpm:
-	@if ! which nfpm 2>&1 >/dev/null ; then \
-		echo 'missing nfpm; see Makefile.release for recipes' && \
-		exit 1; \
-	fi
-
-sha256sum:
-	@if ! which sha256sum 2>&1 >/dev/null ; then \
-		echo 'missing sha256sum; see Makefile.release for recipes' && \
-		exit 1; \
-	fi
-
-rpmbuild:
-	@if ! which rpmbuild 2>&1 >/dev/null ; then \
-		echo 'missing rpmbuild; see Makefile.release for recipes' && \
-		exit 1; \
-	fi
-
-NFPM_VERSION := 0.9.3
-#from https://github.com/goreleaser/nfpm/releases/download/v0.9.3/nfpm_0.9.3_checksums.txt
-NFPM_SHA256 := f875ac060a30ec5c164e5444a7278322b276707493fa0ced6bfdd56640f0a6ea
-
-# Tools installation recipes
-#
-# These are fragile, non-portable, and often require root
-#
-nfpm-debian:
-	cd /tmp && \
-		curl -Ls https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz > nfpm.tar.gz && \
-		echo "${NFPM_SHA256}  nfpm.tar.gz" | \
-		sha256sum -c && \
-		tar xzvf nfpm.tar.gz && \
-		mv nfpm /usr/local/bin
-
-rpmbuild-debian:
-	apt update -q && apt install rpm -yq
-
-rpmbuild-darwin:
-	brew install rpm
-
-sha256sum-darwin:
-	brew install coreutils && ln -s $$(which gsha256sum) /usr/local/bin/sha256sum`
 
 .PHONY: \
 	gh-release \
@@ -135,10 +92,4 @@ sha256sum-darwin:
 	publish-github-rpm \
 	publish-github-deb \
 	publish-github-darwin \
-	release \
-	nfpm \
-	sha256sum \
-	nfpm-debian \
-	rpmbuild-debian \
-	rpmbuild-darwin \
-	sha256sum-darwin
+	release

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -23,7 +23,11 @@ rpmbuild-darwin:
 sha256sum-darwin:
 	brew install coreutils && ln -s $$(which gsha256sum) /usr/local/bin/sha256sum`
 
+github-release:
+	go get -u github.com/aktau/github-release
+
 .PHONY: nfpm-debian \
 	rpmbuild-debian \
 	rpmbuild-darwin \
-	sha256sum-darwin
+	sha256sum-darwin \
+	github-release

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -26,8 +26,12 @@ sha256sum-darwin:
 github-release:
 	go get -u github.com/aktau/github-release
 
+package_cloud:
+	gem install package_cloud
+
 .PHONY: nfpm-debian \
 	rpmbuild-debian \
 	rpmbuild-darwin \
 	sha256sum-darwin \
-	github-release
+	github-release \
+	package_cloud

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -1,0 +1,29 @@
+# Tools installation recipes
+#
+# These are fragile, non-portable, and often require root
+#
+NFPM_VERSION := 0.9.3
+#from https://github.com/goreleaser/nfpm/releases/download/v0.9.3/nfpm_0.9.3_checksums.txt
+NFPM_SHA256 := f875ac060a30ec5c164e5444a7278322b276707493fa0ced6bfdd56640f0a6ea
+
+nfpm-debian:
+	cd /tmp && \
+		curl -Ls https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz > nfpm.tar.gz && \
+		echo "${NFPM_SHA256}  nfpm.tar.gz" | \
+		sha256sum -c && \
+		tar xzvf nfpm.tar.gz && \
+		mv nfpm /usr/local/bin
+
+rpmbuild-debian:
+	apt update -q && apt install rpm -yq
+
+rpmbuild-darwin:
+	brew install rpm
+
+sha256sum-darwin:
+	brew install coreutils && ln -s $$(which gsha256sum) /usr/local/bin/sha256sum`
+
+.PHONY: nfpm-debian \
+	rpmbuild-debian \
+	rpmbuild-darwin \
+	sha256sum-darwin

--- a/nfpm.yaml.tmpl
+++ b/nfpm.yaml.tmpl
@@ -1,0 +1,18 @@
+name: "chamber"
+arch: "amd64"
+platform: "linux"
+version: "${VERSION}"
+section: "default"
+priority: "extra"
+provides:
+- chamber
+vendor: 'Segment, Inc.'
+homepage: "https://github.com/segmentio/chamber"
+license: "MIT"
+# IMHO packages should install to /usr/bin
+bindir: /usr/bin
+files:
+  "${DIST_BIN}": "/usr/bin/chamber"
+description: |
+  Chamber is a tool for managing secrets. Currently it does so by storing
+  secrets in SSM Parameter Store, an AWS service for storing secrets.

--- a/nfpm.yaml.tmpl
+++ b/nfpm.yaml.tmpl
@@ -7,6 +7,7 @@ priority: "extra"
 provides:
 - chamber
 vendor: 'Segment, Inc.'
+maintainer: tooling-team@segment.com
 homepage: "https://github.com/segmentio/chamber"
 license: "MIT"
 # IMHO packages should install to /usr/bin

--- a/nfpm.yaml.tmpl
+++ b/nfpm.yaml.tmpl
@@ -13,6 +13,6 @@ license: "MIT"
 bindir: /usr/bin
 files:
   "${DIST_BIN}": "/usr/bin/chamber"
-description: |
+description: >
   Chamber is a tool for managing secrets. Currently it does so by storing
   secrets in SSM Parameter Store, an AWS service for storing secrets.


### PR DESCRIPTION
- Build deb/rpm packages in `dist` job, using nfpm
- Split `Makefile` in to `Makefile` (simple; mostly aimed at users who want to build it themselves), `Makefile.release` (complex; aimed at CI/devs) and `Makefile.tools` (one-off installation tasks)
- Add `test` job/recipe
- Publish prerelease tags (e.g. `v2.1.0-anythingwithadash`) as github prereleases (mostly for testing this process)
- Publish binaries, packages, and sha256sum to a Github release
- Publish packages to PackageCloud

Ended up refactoring a lot of the Makefile and fixing circle in general. I had to use a fair few GNU Make tricks to get it to work in the end; maybe that's crazy

# Testing deb
```
$ docker run -it -v `pwd`:/tmp debian sh
# cd /tmp
# dpkg -i chamber_v2.1.0-prerelease-test-dev_amd64.deb
dpkg: warning: parsing file '/var/lib/dpkg/tmp.ci/control' near line 12 package 'chamber':
 missing maintainer
Selecting previously unselected package chamber.
(Reading database ... 6498 files and directories currently installed.)
Preparing to unpack chamber_v2.1.0-prerelease-test-dev_amd64.deb ...
Unpacking chamber (2.1.0-prerelease-test-dev) ...
Setting up chamber (2.1.0-prerelease-test-dev) ...
# chamber version
chamber v2.1.0-prerelease-test-dev
```

# Testing rpm
```
$ docker run -it -v `pwd`:/tmp fedora sh
sh-4.4# cd /tmp
sh-4.4# rpm -i chamber_v2.1.0-prerelease-test-dev_amd64.rpm
sh-4.4# chamber version
chamber v2.1.0-prerelease-test-dev
```

# Testing tags
* `git tag v2.1.0-prerelease-test ; git push origin v2.1.0-prerelease-test`
* Triggered this workflow https://circleci.com/workflow-run/17b45616-28d0-49eb-802d-79a7d2936996
* And this release https://github.com/segmentio/chamber/releases/tag/v2.1.0-prerelease-test

# Testing Packagecloud releases
* `git tag -f v2.1.0-prerelease-test3 && git push -f origin v2.1.0-prerelease-test3`
* Triggered this workflow: https://circleci.com/workflow-run/4c05c0de-d48f-45af-9f89-9c96bace1db1
* And this package: https://packagecloud.io/segment/chamber-prerelease/packages/debian/stretch/chamber_2.1.0-prerelease-test3_amd64.deb

# Installing via apt on debian

```
$ docker run -it debian sh -c 'apt update -q && apt install -yq curl && curl -s https://packagecloud.io/install/repositories/segment/chamber-prerelease/script.deb.sh | bash >/dev/null 2>&1 && apt install -yq chamber && chamber version'
...
Get:1 https://packagecloud.io/segment/chamber-prerelease/debian stretch/main amd64 chamber amd64 2.1.0-prerelease-test3 [4896 kB]
Fetched 4896 kB in 1s (4246 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package chamber.
(Reading database ... 7291 files and directories currently installed.)
Preparing to unpack .../chamber_2.1.0-prerelease-test3_amd64.deb ...
Unpacking chamber (2.1.0-prerelease-test3) ...
Setting up chamber (2.1.0-prerelease-test3) ...
chamber v2.1.0-prerelease-test3
```

# Installing via yum on fedora
```
$ docker run -it fedora sh -c 'curl -s https://packagecloud.io/install/repositories/segment/chamber-prerelease/script.rpm.sh | bash && yum install -y chamber && chamber version'
Detected operating system as fedora/28.
Checking for curl...
Detected curl...
Downloading repository file: https://packagecloud.io/install/repositories/segment/chamber-prerelease/config_file.repo?os=fedora&dist=28&source=script
done.
Installing pygpgme to verify GPG signatures...
Fedora 28 - x86_64 - Updates                                                                                                                        13 MB/s |  24 MB     00:01
Fedora 28 - x86_64                                                                                                                                  16 MB/s |  60 MB     00:03
Importing GPG key 0x06C8B876:
 Userid     : "https://packagecloud.io/segment/chamber-prerelease (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
 Fingerprint: 2965 CB52 8B88 897F EEE5 6625 90F4 AD12 06C8 B876
 From       : https://packagecloud.io/segment/chamber-prerelease/gpgkey
segment_chamber-prerelease-source                                                                                                                  781  B/s | 296  B     00:00
...

Total download size: 4.6 M
Installed size: 17 M
Downloading Packages:
chamber-2.1.0_prerelease_test4-1.x86_64.rpm                                                                                                        8.2 MB/s | 4.6 MB     00:00
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                              8.1 MB/s | 4.6 MB     00:00
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                           1/1
  Running scriptlet: chamber-2.1.0_prerelease_test4-1.x86_64                                                                                                                   1/1
  Installing       : chamber-2.1.0_prerelease_test4-1.x86_64                                                                                                                   1/1
  Running scriptlet: chamber-2.1.0_prerelease_test4-1.x86_64                                                                                                                   1/1
  Verifying        : chamber-2.1.0_prerelease_test4-1.x86_64                                                                                                                   1/1

Installed:
  chamber.x86_64 2.1.0_prerelease_test4-1

Complete!
chamber v2.1.0-prerelease-test4
```