### PR TITLE
Print env var keys on exec with a global`-v` flag

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -39,6 +39,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 
 	env := environ(os.Environ())
 	secretStore := getSecretStore()
+	envVarKeys := make([]string, 0)
 	for _, service := range services {
 		if err := validateService(service); err != nil {
 			return errors.Wrap(err, "Failed to validate service")
@@ -52,11 +53,17 @@ func execRun(cmd *cobra.Command, args []string) error {
 			envVarKey := strings.ToUpper(key(rawSecret.Key))
 			envVarKey = strings.Replace(envVarKey, "-", "_", -1)
 
+			envVarKeys = append(envVarKeys, envVarKey)
+
 			if env.IsSet(envVarKey) {
 				fmt.Fprintf(os.Stderr, "warning: overwriting environment variable %s\n", envVarKey)
 			}
 			env.Set(envVarKey, rawSecret.Value)
 		}
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stdout, "info: With environment %s\n", strings.Join(envVarKeys, ","))
 	}
 
 	return exec(command, commandArgs, env)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ var (
 	validKeyFormat     = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
 	validServiceFormat = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
 
+	verbose        bool
 	numRetries     int
 	chamberVersion string
 )
@@ -45,6 +46,7 @@ var RootCmd = &cobra.Command{
 
 func init() {
 	RootCmd.PersistentFlags().IntVarP(&numRetries, "retries", "r", DefaultNumRetries, "For SSM, the number of retries we'll make before giving up")
+	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Print more information to STDOUT")
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.


### PR DESCRIPTION
It's useful to know the exact keys that are picked up by Chamber as that
information is not otherwise available anywhere else