### PR TITLE
Handle errors in secret store constructors.

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -31,7 +31,10 @@ func delete(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := getSecretStore()
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -38,7 +38,10 @@ func execRun(cmd *cobra.Command, args []string) error {
 	services, command, commandArgs := args[:dashIx], args[dashIx], args[dashIx+1:]
 
 	env := environ(os.Environ())
-	secretStore := getSecretStore()
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
 	envVarKeys := make([]string, 0)
 	for _, service := range services {
 		if err := validateService(service); err != nil {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -37,7 +37,10 @@ func init() {
 func runExport(cmd *cobra.Command, args []string) error {
 	var err error
 
-	secretStore := getSecretStore()
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return err
+	}
 	params := make(map[string]string)
 	for _, service := range args {
 		if err := validateService(service); err != nil {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -34,7 +34,10 @@ func history(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := getSecretStore()
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -51,7 +51,10 @@ func importRun(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to decode input as json")
 	}
 
-	secretStore := getSecretStore()
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
 
 	for key, value := range toBeImported {
 		secretId := store.SecretId{

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,7 +33,11 @@ func list(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
-	secretStore := getSecretStore()
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
+
 	secrets, err := secretStore.List(service, withValues)
 	if err != nil {
 		return errors.Wrap(err, "Failed to list store contents")

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -41,7 +41,10 @@ func read(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := getSecretStore()
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
 
 	secretId := store.SecretId{
 		Service: service,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,17 +84,18 @@ func validateKey(key string) error {
 	return nil
 }
 
-func getSecretStore() store.Store {
+func getSecretStore() (store.Store, error) {
 	backend := strings.ToUpper(os.Getenv(BackendEnvVar))
 
 	var s store.Store
+	var err error
 	switch backend {
 	case S3Backend:
-		s = store.NewS3Store(numRetries)
+		s, err = store.NewS3Store(numRetries)
 	case SSMBackend:
 		fallthrough
 	default:
-		s = store.NewSSMStore(numRetries)
+		s, err = store.NewSSMStore(numRetries)
 	}
-	return s
+	return s, err
 }

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -58,7 +58,11 @@ func write(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	secretStore := getSecretStore()
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
+
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/store/backendbenchmarks_test.go
+++ b/store/backendbenchmarks_test.go
@@ -73,7 +73,7 @@ func TestS3StoreConcurrency(t *testing.T) {
 	if !benchmarkEnabled {
 		t.SkipNow()
 	}
-	s := NewS3Store(10)
+	s, _ := NewS3Store(10)
 	benchmarkStore(t, s, []string{"foo"})
 }
 
@@ -81,7 +81,7 @@ func TestSSMConcurrency(t *testing.T) {
 	if !benchmarkEnabled {
 		t.SkipNow()
 	}
-	s := NewSSMStore(10)
+	s, _ := NewSSMStore(10)
 	benchmarkStore(t, s, []string{"foo"})
 }
 

--- a/store/shared.go
+++ b/store/shared.go
@@ -12,13 +12,13 @@ const (
 	RegionEnvVar = "CHAMBER_AWS_REGION"
 )
 
-func getSession(numRetries int) (*session.Session, *string) {
+func getSession(numRetries int) (*session.Session, *string, error) {
 	var region *string
 
 	if regionOverride, ok := os.LookupEnv(RegionEnvVar); ok {
 		region = aws.String(regionOverride)
 	}
-	retSession := session.Must(session.NewSessionWithOptions(
+	retSession, err := session.NewSessionWithOptions(
 		session.Options{
 			Config: aws.Config{
 				Region:     region,
@@ -26,7 +26,10 @@ func getSession(numRetries int) (*session.Session, *string) {
 			},
 			SharedConfigState: session.SharedConfigEnable,
 		},
-	))
+	)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// If region is still not set, attempt to determine it via ec2 metadata API
 	if aws.StringValue(retSession.Config.Region) == "" {
@@ -37,5 +40,5 @@ func getSession(numRetries int) (*session.Session, *string) {
 		}
 	}
 
-	return retSession, region
+	return retSession, region, nil
 }

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -37,8 +37,11 @@ type SSMStore struct {
 }
 
 // NewSSMStore creates a new SSMStore
-func NewSSMStore(numRetries int) *SSMStore {
-	ssmSession, region := getSession(numRetries)
+func NewSSMStore(numRetries int) (*SSMStore, error) {
+	ssmSession, region, err := getSession(numRetries)
+	if err != nil {
+		return nil, err
+	}
 
 	svc := ssm.New(ssmSession, &aws.Config{
 		MaxRetries: aws.Int(numRetries),
@@ -54,7 +57,7 @@ func NewSSMStore(numRetries int) *SSMStore {
 	return &SSMStore{
 		svc:      svc,
 		usePaths: usePaths,
-	}
+	}, nil
 }
 
 func (s *SSMStore) KMSKey() string {

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -288,7 +288,8 @@ func TestNewSSMStore(t *testing.T) {
 		os.Setenv("AWS_REGION", "us-west-1")
 		os.Setenv("AWS_DEFAULT_REGION", "us-west-2")
 
-		s := NewSSMStore(1)
+		s, err := NewSSMStore(1)
+		assert.Nil(t, err)
 		assert.Equal(t, "us-east-1", aws.StringValue(s.svc.(*ssm.SSM).Config.Region))
 		os.Unsetenv("CHAMBER_AWS_REGION")
 		os.Unsetenv("AWS_REGION")
@@ -298,7 +299,8 @@ func TestNewSSMStore(t *testing.T) {
 	t.Run("Should use AWS_REGION if it is set", func(t *testing.T) {
 		os.Setenv("AWS_REGION", "us-west-1")
 
-		s := NewSSMStore(1)
+		s, err := NewSSMStore(1)
+		assert.Nil(t, err)
 		assert.Equal(t, "us-west-1", aws.StringValue(s.svc.(*ssm.SSM).Config.Region))
 
 		os.Unsetenv("AWS_REGION")


### PR DESCRIPTION
Fixes panic on bad aws configuration.

Before:

```
~/g/s/g/s/chamber 🤜 chamber list foo                                                         ✘ 130 fix-panic-bad-aws-session ✭ ◼
panic: AssumeRoleTokenProviderNotSetError: assume role with MFA enabled, but AssumeRoleTokenProvider session option not set.

goroutine 1 [running]:
github.com/aws/aws-sdk-go/aws/session.Must(...)
        /Users/joshuacarp/go/src/github.com/aws/aws-sdk-go/aws/session/session.go:281
github.com/segmentio/chamber/store.getSession(0xa, 0x16e7b92, 0x16)
        /Users/joshuacarp/go/src/github.com/segmentio/chamber/store/shared.go:21 +0x284
github.com/segmentio/chamber/store.NewSSMStore(0xa, 0x0)
        /Users/joshuacarp/go/src/github.com/segmentio/chamber/store/ssmstore.go:41 +0x2f
github.com/segmentio/chamber/cmd.getSecretStore(0x7ffeefbff435, 0x3)
        /Users/joshuacarp/go/src/github.com/segmentio/chamber/cmd/root.go:86 +0x8c
github.com/segmentio/chamber/cmd.list(0x1c48a20, 0xc000091710, 0x1, 0x1, 0x0, 0x0)
        /Users/joshuacarp/go/src/github.com/segmentio/chamber/cmd/list.go:36 +0xcc
github.com/spf13/cobra.(*Command).execute(0x1c48a20, 0xc0000916e0, 0x1, 0x1, 0x1c48a20, 0xc0000916e0)
        /Users/joshuacarp/go/src/github.com/spf13/cobra/command.go:762 +0x473
github.com/spf13/cobra.(*Command).ExecuteC(0x1c48ee0, 0xc0001c5f00, 0xc0001c5f88, 0x10071b0)
        /Users/joshuacarp/go/src/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/segmentio/chamber/cmd.Execute(0x16df004, 0x3)
        /Users/joshuacarp/go/src/github.com/segmentio/chamber/cmd/root.go:54 +0x56
main.main()
        /Users/joshuacarp/go/src/github.com/segmentio/chamber/main.go:11 +0x39
```

After:

```
~/g/s/g/s/chamber 🤜 chamber list foo                                                         ✘ 2 fix-panic-bad-aws-session ✭ ◼
Error: Failed to get secret store: AssumeRoleTokenProviderNotSetError: assume role with MFA enabled, but AssumeRoleTokenProvider session option not set.
```