### PR TITLE
Adding analytics for usage metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@
 # This makefile is meant for humans
 
 VERSION := $(shell git describe --tags --always --dirty="-dev")
-LDFLAGS := -ldflags='-X "main.Version=$(VERSION)"'
+ANALYTICS_WRITE_KEY ?=
+LDFLAGS := -ldflags='-X "main.Version=$(VERSION)" -X "main.AnalyticsWriteKey=$(ANALYTICS_WRITE_KEY)"'
 
 test: | govendor
 	govendor sync

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ To configure chamber to use the S3 backend, set `CHAMBER_SECRET_BACKEND` to `S3`
 
 This feature is experimental, and not currently meant for production work.
 
+## Analytics
+
+`chamber` includes some usage analytics code which Segment uses internally for tracking usage of internal tools.  This analytics code is turned off by default, and can only be enabled via a linker flag at build time, which we do not set for public github releases.
+
 ## Releasing
 
 To cut a new release, just push a tag named `v<semver>` where `<semver>` is a

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,19 @@ func delete(cmd *cobra.Command, args []string) error {
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "delete").
+				Set("chamber-version", chamberVersion).
+				Set("service", service).
+				Set("key", key).
+				Set("backend", backend),
+		})
 	}
 
 	secretStore := getSecretStore()

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go"
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +37,18 @@ func init() {
 func execRun(cmd *cobra.Command, args []string) error {
 	dashIx := cmd.ArgsLenAtDash()
 	services, command, commandArgs := args[:dashIx], args[dashIx], args[dashIx+1:]
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "exec").
+				Set("chamber-version", chamberVersion).
+				Set("services", services).
+				Set("backend", backend),
+		})
+	}
 
 	env := environ(os.Environ())
 	secretStore := getSecretStore()

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/magiconair/properties"
 	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go"
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +37,18 @@ func init() {
 
 func runExport(cmd *cobra.Command, args []string) error {
 	var err error
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "export").
+				Set("chamber-version", chamberVersion).
+				Set("services", args).
+				Set("backend", backend),
+		})
+	}
 
 	secretStore := getSecretStore()
 	params := make(map[string]string)

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -32,6 +33,19 @@ func history(cmd *cobra.Command, args []string) error {
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "history").
+				Set("chamber-version", chamberVersion).
+				Set("service", service).
+				Set("key", key).
+				Set("backend", backend),
+		})
 	}
 
 	secretStore := getSecretStore()

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -49,6 +50,18 @@ func importRun(cmd *cobra.Command, args []string) error {
 	decoder := json.NewDecoder(in)
 	if err := decoder.Decode(&toBeImported); err != nil {
 		return errors.Wrap(err, "Failed to decode input as json")
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "import").
+				Set("chamber-version", chamberVersion).
+				Set("service", service).
+				Set("backend", backend),
+		})
 	}
 
 	secretStore := getSecretStore()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +32,18 @@ func list(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "list").
+				Set("chamber-version", chamberVersion).
+				Set("service", service).
+				Set("backend", backend),
+		})
 	}
 
 	secretStore := getSecretStore()

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -53,8 +53,6 @@ func read(cmd *cobra.Command, args []string) error {
 				Set("key", key).
 				Set("backend", backend),
 		})
-	} else {
-		fmt.Println("Not writing!!")
 	}
 
 	secretStore := getSecretStore()

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -39,6 +40,21 @@ func read(cmd *cobra.Command, args []string) error {
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "read").
+				Set("chamber-version", chamberVersion).
+				Set("service", service).
+				Set("key", key).
+				Set("backend", backend),
+		})
+	} else {
+		fmt.Println("Not writing!!")
 	}
 
 	secretStore := getSecretStore()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	analytics "github.com/segmentio/analytics-go"
 	"github.com/spf13/cobra"
 )
 
@@ -20,5 +21,15 @@ func init() {
 
 func versionRun(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "chamber %s\n", chamberVersion)
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "version").
+				Set("chamber-version", chamberVersion).
+				Set("backend", backend),
+		})
+	}
 	return nil
 }

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -37,6 +38,19 @@ func write(cmd *cobra.Command, args []string) error {
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "write").
+				Set("chamber-version", chamberVersion).
+				Set("service", service).
+				Set("backend", backend).
+				Set("key", key),
+		})
 	}
 
 	value := args[2]

--- a/main.go
+++ b/main.go
@@ -4,9 +4,10 @@ import "github.com/segmentio/chamber/cmd"
 
 var (
 	// This is updated by linker flags during build
-	Version = "dev"
+	Version           = "dev"
+	AnalyticsWriteKey = ""
 )
 
 func main() {
-	cmd.Execute(Version)
+	cmd.Execute(Version, AnalyticsWriteKey)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -245,6 +245,12 @@
 			"revisionTime": "2014-10-17T20:07:13Z"
 		},
 		{
+			"checksumSHA1": "WbdgSkC2Tbn1Fs1WAAvXPHBvkEk=",
+			"path": "github.com/jehiah/go-strftime",
+			"revision": "1d33003b386959af197ba96475f198c114627b5e",
+			"revisionTime": "2017-12-01T14:10:54Z"
+		},
+		{
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",
 			"origin": "github.com/aws/aws-sdk-go/vendor/github.com/jmespath/go-jmespath",
 			"path": "github.com/jmespath/go-jmespath",
@@ -271,6 +277,20 @@
 			"revisionTime": "2016-01-29T19:31:06Z"
 		},
 		{
+			"checksumSHA1": "8xpFdZVp0QVAhbq20SJEb4qTcEk=",
+			"path": "github.com/segmentio/analytics-go",
+			"revision": "4f08212e9b32c48b4a4d20997d3f90dc0b56eba8",
+			"revisionTime": "2018-03-19T16:54:24Z",
+			"version": "v3.0",
+			"versionExact": "v3.0"
+		},
+		{
+			"checksumSHA1": "jK8cjKr2eA3JiQP+T4HLjQRV5ak=",
+			"path": "github.com/segmentio/backo-go",
+			"revision": "204274ad699c0983a70203a566887f17a717fef4",
+			"revisionTime": "2016-04-24T05:23:52Z"
+		},
+		{
 			"checksumSHA1": "aG5wPXVGAEu90TjPFNZFRtox2Zo=",
 			"path": "github.com/spf13/cobra",
 			"revision": "ccaecb155a2177302cb56cae929251a256d0f646",
@@ -287,6 +307,12 @@
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "9f9027faeb0dad515336ed2f28317f9f8f527ab4",
 			"revisionTime": "2016-01-29T19:31:06Z"
+		},
+		{
+			"checksumSHA1": "LAL/r7KfCdqp4M6MM13+7NWsUNc=",
+			"path": "github.com/xtgo/uuid",
+			"revision": "a0b114877d4caeffbd7f87e3757c17fce570fea7",
+			"revisionTime": "2014-08-04T02:12:11Z"
 		}
 	],
 	"rootPath": "github.com/segmentio/chamber"


### PR DESCRIPTION
This adds metrics to chamber so we can track internal company usage of the tool. Chamber built for open source will not have the linked analytics key.

This PR basically copies the way metrics were added to aws-okta