### PR TITLE
Allow prefix to be set that is prepended to services

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,20 @@ for more details.
 
 If you'd like to use a different region for chamber without changing `AWS_REGION`, you can use `CHAMBER_AWS_REGION` to override just for chamber.
 
+### Service Prefix
+
+If `CHAMBER_SERVICE_PREFIX` is set, chamber will prefix all services with its value. This can be useful when you want to namespace your configuration without having to repeat it in each service key.
+
+For example, these are equivalant:
+
+```
+# Store value under 'applications\service\key'
+chamber write applications\service key value
+
+# Also stores value under 'applications\service/key'
+CHAMBER_SERVICE_PREFIX=applications write service key value
+```
+
 ## S3 Backend (experimental)
 
 By default, chamber store secrets in AWS Parameter Store.  We now also provide an experimental S3 backend for storing secrets in S3 instead.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 func delete(cmd *cobra.Command, args []string) error {
-	service := strings.ToLower(args[0])
+	service := formatService(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -44,11 +44,12 @@ func execRun(cmd *cobra.Command, args []string) error {
 	}
 	envVarKeys := make([]string, 0)
 	for _, service := range services {
+		service = formatService(service)
 		if err := validateService(service); err != nil {
 			return errors.Wrap(err, "Failed to validate service")
 		}
 
-		rawSecrets, err := secretStore.ListRaw(strings.ToLower(service))
+		rawSecrets, err := secretStore.ListRaw(service)
 		if err != nil {
 			return errors.Wrap(err, "Failed to list store contents")
 		}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -43,6 +43,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 	}
 	params := make(map[string]string)
 	for _, service := range args {
+		service = formatService(service)
 		if err := validateService(service); err != nil {
 			return errors.Wrapf(err, "Failed to validate service %s", service)
 		}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func history(cmd *cobra.Command, args []string) error {
-	service := strings.ToLower(args[0])
+	service := formatService(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
@@ -26,7 +25,7 @@ func init() {
 }
 
 func importRun(cmd *cobra.Command, args []string) error {
-	service := strings.ToLower(args[0])
+	service := formatService(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func list(cmd *cobra.Command, args []string) error {
-	service := strings.ToLower(args[0])
+	service := formatService(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func read(cmd *cobra.Command, args []string) error {
-	service := strings.ToLower(args[0])
+	service := formatService(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@ var (
 	validServiceFormat     = regexp.MustCompile(`^[\w\-\.]+$`)
 	validServicePathFormat = regexp.MustCompile(`^[\w\-\.]+(\/[\w\-\.]+)*$`)
 
+	servicePrefix = os.Getenv("CHAMBER_SERVICE_PREFIX")
+
 	verbose        bool
 	numRetries     int
 	chamberVersion string
@@ -60,6 +62,10 @@ func Execute(vers string) {
 		}
 		os.Exit(1)
 	}
+}
+
+func formatService(service string) string {
+	return servicePrefix + strings.ToLower(service)
 }
 
 func validateService(service string) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFormatService(t *testing.T) {
+
+	t.Run("it lower cases the service", func(t *testing.T) {
+		servicePrefix = ""
+		assert.Equal(t, "webserver", formatService("WEBSERVER"))
+	})
+
+	t.Run("it prepends service with prefix when present", func(t *testing.T) {
+		servicePrefix = "environment/"
+		assert.Equal(t, "environment/webserver", formatService("WEBSERVER"))
+	})
+}
+
 func TestValidations(t *testing.T) {
 
 	// Test Key formats

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 func write(cmd *cobra.Command, args []string) error {
-	service := strings.ToLower(args[0])
+	service := formatService(args[0])
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}


### PR DESCRIPTION
## what

When `CHAMBER_SERVICE_PREFIX` is set, the value is prepended to all services when access the store

## why

Issue: https://github.com/segmentio/chamber/issues/128

This simplifies organizing keys in the store. A common use case would when you have multiple environments that the services are deployed to. By setting the prefix the same chamber command be run across all environments.