### PR TITLE
Addition of a NULL Backend to provide a simple way of disabling backend lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ To configure chamber to use the S3 backend, set `CHAMBER_SECRET_BACKEND` to `S3`
 
 This feature is experimental, and not currently meant for production work.
 
+## Null Backend (experimental)
+
+If it's preferred to not use any backend at all, set `CHAMBER_SECRET_BACKEND` to `NULL`. Doing so will forward existing ENV variables as if Chamber is not in between.
+
+This feature is experimental, and not currently meant for production work.
+
+
 ## Releasing
 
 To cut a new release, just push a tag named `v<semver>` where `<semver>` is a

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,13 +30,14 @@ const (
 )
 
 const (
+	NullBackend = "NULL"
 	SSMBackend = "SSM"
 	S3Backend  = "S3"
 
 	BackendEnvVar = "CHAMBER_SECRET_BACKEND"
 )
 
-var Backends = []string{SSMBackend, S3Backend}
+var Backends = []string{SSMBackend, S3Backend, NullBackend}
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -90,6 +91,8 @@ func getSecretStore() (store.Store, error) {
 	var s store.Store
 	var err error
 	switch backend {
+	case NullBackend:
+		s = store.NewNullStore()
 	case S3Backend:
 		s, err = store.NewS3Store(numRetries)
 	case SSMBackend:

--- a/store/nullstore.go
+++ b/store/nullstore.go
@@ -1,0 +1,37 @@
+package store
+
+import (
+	"errors"
+)
+
+var _ Store = &NullStore{}
+
+type NullStore struct{}
+
+func NewNullStore() *NullStore {
+	return &NullStore{}
+}
+
+func (s *NullStore) Write(id SecretId, value string) error {
+	return errors.New("Write is not implemented for Null Store")
+}
+
+func (s *NullStore) Read(id SecretId, version int) (Secret, error) {
+	return Secret{}, errors.New("Not implemented for Null Store")
+}
+
+func (s *NullStore) List(service string, includeValues bool) ([]Secret, error) {
+	return []Secret{}, nil
+}
+
+func (s *NullStore) ListRaw(service string) ([]RawSecret, error) {
+	return []RawSecret{}, nil
+}
+
+func (s *NullStore) History(id SecretId) ([]ChangeEvent, error) {
+	return []ChangeEvent{}, nil
+}
+
+func (s *NullStore) Delete(id SecretId) error {
+	return errors.New("Not implemented for Null Store")
+}


### PR DESCRIPTION
## What

The addition of a `NULL` backend store, next to `s3` and `ssm`. Invoked by the ENV variable `CHAMBER_SECRET_BACKEND` set to `NULL`. The null-backend has no actual backend. Chamber will simply transparently pass through ENV vars.  https://github.com/segmentio/chamber/issues/143 is the related issue.

## Why

In some use cases the transformation into using Chamber inside an (external) organisation is not always straight forward. In many cases it is not only a migration on AWS from using ENV to using SSM/KMS, but also a migration from other providers like Heroku to AWS. To be able to get an organisation prepared with applications still sitting outside of AWS, with various teams and various docker orchestrations, it would be great to already have chamber implemented in a lazy way without the need to set the`ENTRYPOINT` or `CMD`, as this is not always possible.
