### PR TITLE
Quote environment variables.

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -15,6 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const doubleQuoteSpecialChars = "\\\n\r\"!$`"
+
 // exportCmd represents the export command
 var (
 	exportFormat string
@@ -100,7 +102,7 @@ func exportAsEnvFile(params map[string]string, w io.Writer) error {
 	for _, k := range sortedKeys(params) {
 		key := strings.ToUpper(k)
 		key = strings.Replace(key, "-", "_", -1)
-		w.Write([]byte(fmt.Sprintf("%s=%s\n", key, params[k])))
+		w.Write([]byte(fmt.Sprintf(`%s="%s"`+"\n", key, doubleQuoteEscape(params[k]))))
 	}
 	return nil
 }
@@ -163,4 +165,18 @@ func sortedKeys(params map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func doubleQuoteEscape(line string) string {
+	for _, c := range doubleQuoteSpecialChars {
+		toReplace := "\\" + string(c)
+		if c == '\n' {
+			toReplace = `\n`
+		}
+		if c == '\r' {
+			toReplace = `\r`
+		}
+		line = strings.Replace(line, string(c), toReplace, -1)
+	}
+	return line
 }

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExportDotenv(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]string
+		output []string
+	}{
+		{
+			"simple",
+			map[string]string{"foo": "bar"},
+			[]string{`FOO="bar"`},
+		},
+		{
+			"escaped dollar",
+			map[string]string{"foo": "bar", "baz": "$qux"},
+			[]string{`FOO="bar"`, `BAZ="\$qux"`},
+		},
+		{
+			"escaped quote",
+			map[string]string{"foo": "bar", "baz": `"qux"`},
+			[]string{`FOO="bar"`, `BAZ="\"qux\""`},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			err := exportAsEnvFile(test.params, buf)
+			assert.Nil(t, err)
+			assert.ElementsMatch(t, test.output, strings.Split(strings.Trim(buf.String(), "\n"), "\n"))
+		})
+	}
+}


### PR DESCRIPTION
Fixes dotenv export for variables with newlines and other special
characters.

Escape helper borrowed from https://github.com/joho/godotenv/blob/master/godotenv.go (MIT licensed).