### PR TITLE
Remove extra history entry for the current parameter version

### DIFF
--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -163,16 +163,6 @@ func (s *SSMStore) readVersion(id SecretId, version int) (Secret, error) {
 		}
 	}
 
-	// If we havent found it yet, check the latest version (which
-	// doesnt get returned from GetParameterHistory)
-	current, err := s.readLatest(id)
-	if err != nil {
-		return Secret{}, err
-	}
-	if current.Meta.Version == version {
-		return current, nil
-	}
-
 	return Secret{}, ErrSecretNotFound
 }
 
@@ -409,18 +399,6 @@ func (s *SSMStore) History(id SecretId) ([]ChangeEvent, error) {
 		})
 	}
 
-	// The current version is not included in the GetParameterHistory response
-	current, err := s.Read(id, -1)
-	if err != nil {
-		return events, err
-	}
-
-	events = append(events, ChangeEvent{
-		Type:    getChangeType(current.Meta.Version),
-		Time:    current.Meta.Created,
-		User:    current.Meta.CreatedBy,
-		Version: current.Meta.Version,
-	})
 	return events, nil
 }
 


### PR DESCRIPTION
At some point the SSM `GetParameterHistory` call started returning the current version in its response. (My guess is that this might have happened when AWS introduced official support for versioning, though I haven't confirmed that.) That turns the various old workarounds for the missing "current" version into bugs, like this:

```
$ chamber write myservice mysecret foo
$ chamber history myservice mysecret 
Event		Version		Date		User
Created		1		10-13 17:37:21	[redacted]
Created		1		10-13 17:37:21	[redacted]

$ chamber write myservice mysecret bar
$ chamber history myservice mysecret 
Event		Version		Date		User
Created		1		10-13 17:37:21	[redacted]
Updated		2		10-13 17:37:48	[redacted]
Updated		2		10-13 17:37:48	[redacted]
```

This PR fixes that. After the fix:
```
$ chamber write myservice mysecret foo
$ chamber history myservice mysecret 
Event		Version		Date		User
Created		1		10-13 17:48:15	[redacted]

$ chamber write myservice mysecret bar
$ chamber history myservice mysecret 
Event		Version		Date		User
Created		1		10-13 17:48:15	[redacted]
Updated		2		10-13 17:48:21	[redacted]
```