### PR TITLE
Fix missing history and failed reads beyond secret version 50

### DIFF
--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -191,6 +191,15 @@ func (m *mockSSMClient) DescribeParametersPages(i *ssm.DescribeParametersInput, 
 	return nil
 }
 
+func (m *mockSSMClient) GetParameterHistoryPages(i *ssm.GetParameterHistoryInput, fn func(*ssm.GetParameterHistoryOutput, bool) bool) error {
+	o, err := m.GetParameterHistory(i)
+	if err != nil {
+		return err
+	}
+	fn(o, true)
+	return nil
+}
+
 func (m *mockSSMClient) DeleteParameter(i *ssm.DeleteParameterInput) (*ssm.DeleteParameterOutput, error) {
 	_, ok := m.parameters[*i.Name]
 	if !ok {


### PR DESCRIPTION
Fixes issue #86 - because the `GetParameterHistory` API is limited to 50 results per request, secret versions greater than 50 did not show up in the history and could not be retrieved.