### PR TITLE
Fix 2 typos

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -69,7 +69,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 		for _, rawSecret := range rawSecrets {
 			k := key(rawSecret.Key)
 			if _, ok := params[k]; ok {
-				fmt.Fprintf(os.Stderr, "warning: parameter %s specified more than once (overriden by service %s)\n", k, service)
+				fmt.Fprintf(os.Stderr, "warning: parameter %s specified more than once (overridden by service %s)\n", k, service)
 			}
 			params[k] = rawSecret.Value
 		}

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -379,7 +379,7 @@ func (s *SSMStore) ListRaw(service string) ([]RawSecret, error) {
 	return s.listRawViaList(service)
 }
 
-// History returns a list of events that have occured regarding the given
+// History returns a list of events that have occurred regarding the given
 // secret.
 func (s *SSMStore) History(id SecretId) ([]ChangeEvent, error) {
 	events := []ChangeEvent{}


### PR DESCRIPTION
Fix 2 typos detected by `misspell`:
```
cmd/export.go:72:76: "overriden" is a misspelling of "overridden"
store/ssmstore.go:382:46: "occured" is a misspelling of "occurred"
```