### PR TITLE
Support case sensitivity for a few commands

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,16 +18,23 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
+	deleteCmd.Flags().BoolVarP(&caseSensitive, "case-sensitive", "", false, "Enable case sensitive service names and keys. Defaults to lowercase keys and services")
 	RootCmd.AddCommand(deleteCmd)
 }
 
 func delete(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
+	if caseSensitive {
+		service = args[0]
+	}
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	key := strings.ToLower(args[1])
+	if caseSensitive {
+		key = args[1]
+	}
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
 	}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -21,16 +21,23 @@ var historyCmd = &cobra.Command{
 }
 
 func init() {
+	historyCmd.Flags().BoolVarP(&caseSensitive, "case-sensitive", "", false, "Enable case sensitive service names and keys. Defaults to lowercase keys and services")
 	RootCmd.AddCommand(historyCmd)
 }
 
 func history(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
+	if caseSensitive {
+		service = args[0]
+	}
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	key := strings.ToLower(args[1])
+	if caseSensitive {
+		key = args[1]
+	}
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
 	}

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -28,16 +28,23 @@ var (
 func init() {
 	readCmd.Flags().IntVarP(&version, "version", "v", -1, "The version number of the secret. Defaults to latest.")
 	readCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only print the secret")
+	readCmd.Flags().BoolVarP(&caseSensitive, "case-sensitive", "", false, "Enable case sensitive service names and keys. Defaults to lowercase keys and services")
 	RootCmd.AddCommand(readCmd)
 }
 
 func read(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
+	if caseSensitive {
+		service = args[0]
+	}
 	if err := validateService(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	key := strings.ToLower(args[1])
+	if caseSensitive {
+		key = args[1]
+	}
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,8 +11,11 @@ import (
 	analytics "gopkg.in/segmentio/analytics-go.v3"
 )
 
-// Regex's used to validate service and key names
 var (
+	// Boolean used to interact with case sensitive services and keys
+	caseSensitive bool
+
+	// Regex's used to validate service and key names
 	validKeyFormat         = regexp.MustCompile(`^[\w\-\.]+$`)
 	validServiceFormat     = regexp.MustCompile(`^[\w\-\.]+$`)
 	validServicePathFormat = regexp.MustCompile(`^[\w\-\.]+(\/[\w\-\.]+)*$`)


### PR DESCRIPTION
This will add a `--case-sensitive` switch to the following commands:

    * delete
    * history
    * import
    * read

Notably changing the import behaviour to fail an import payload with
mixed case keys

This follows on from previous discussions:

1. #160 is the latest outstanding issue with no comments yet
2. #21 was closed citing duplication protection from user error
3. #66 was closed citing #21 and consistency concerns

In detail this commit will:

  1. Modify `import` to fail an import payload when mixed case keys are provided except when the `--case-sensitive` switch is passed - This closes #160 with the following considerations:
    a. This protects users from themselves
    b. This helps anyone using chamber that currently bulk imports a mismash of case in a single export to be notified to correct their behaviour
    c. This new default behaviour mimics the manual write call that has been defended in similiar PRs, but still allows for the old behaviour with a switch
  2. Modify `delete` by adding a non default `--case-sensitive` switch to delete case sensitive params (which helps clean up any messes made by an existing import)
  3. Modify `history` by adding a non default `--case-sensitive` switch to allow individual case sensitive param history to be read (which allows viewing of history for keys already seen with `list`)
  4. Modify `read` by adding a non default `--case-sensitive` switch to allow individual case sensitive params to be read (which has a tremendous amount of value in allowing a user to read any existing key that wasn't imported with Chamber)

Here's a summary of the current core chamber functions:

  #### Four commands with enforced lowercase consistency
  * `delete` will lowercase all delete calls to SSM
  * `history` will lowercase all history calls to SSM
  * `read` will lowercase all reads from SSM
  * `write` will lowercase all puts to SSM

  #### Four commands break this consistency
  * `exec` returns values as is from SSM except for the `dotenv` output, which will uppercase all keys and keep duplicates
  * `export` will respect case sensitivity, and fetch case sensitive params as is in SSM except the resultant value will be unpredictable, but at least there's a warning about it
  * `import` will respect case sensitivity, and store case sensitive params as is in SSM
  * `list` will respect case sensitivity, and list case sensitive params as is in SSM

Finally, this commit intends to continue to protect the user from doing the wrong thing when writing values thus improving the end user experience, whilst reducing the barrier for new users of Chamber by supporting an existing key structure without compromising on new parameter ideologies