### PR TITLE
export environ as its own lib

### DIFF
--- a/environ/environ.go
+++ b/environ/environ.go
@@ -1,0 +1,85 @@
+package environ
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/chamber/store"
+)
+
+// environ is a slice of strings representing the environment, in the form "key=value".
+type Environ []string
+
+// Unset an environment variable by key
+func (e *Environ) Unset(key string) {
+	for i := range *e {
+		if strings.HasPrefix((*e)[i], key+"=") {
+			(*e)[i] = (*e)[len(*e)-1]
+			*e = (*e)[:len(*e)-1]
+			break
+		}
+	}
+}
+
+// IsSet returns whether or not a key is currently set in the environ
+func (e *Environ) IsSet(key string) bool {
+	for i := range *e {
+		if strings.HasPrefix((*e)[i], key+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+// Set adds an environment variable, replacing any existing ones of the same key
+func (e *Environ) Set(key, val string) {
+	e.Unset(key)
+	*e = append(*e, key+"="+val)
+}
+
+// like cmd/list.key, but without the env var lookup
+func key(s string, noPaths bool) string {
+	sep := "/"
+	if noPaths {
+		sep = "."
+	}
+	tokens := strings.Split(s, sep)
+	secretKey := tokens[len(tokens)-1]
+	return secretKey
+}
+
+// load loads environment variables into e from s given a service
+// collisions will be populated with any keys that get overwritten
+// noPaths enables the behavior as if CHAMBER_NO_PATHS had been set
+func (e *Environ) load(s store.Store, service string, collisions *[]string, noPaths bool) error {
+	rawSecrets, err := s.ListRaw(strings.ToLower(service))
+	if err != nil {
+		return errors.Wrap(err, "Failed to list store contents")
+	}
+	envVarKeys := make([]string, 0)
+	for _, rawSecret := range rawSecrets {
+		envVarKey := strings.ToUpper(key(rawSecret.Key, noPaths))
+		envVarKey = strings.Replace(envVarKey, "-", "_", -1)
+
+		envVarKeys = append(envVarKeys, envVarKey)
+
+		if e.IsSet(envVarKey) {
+			*collisions = append(*collisions, envVarKey)
+		}
+		e.Set(envVarKey, rawSecret.Value)
+	}
+	return nil
+}
+
+// Load loads environment variables into e from s given a service
+// collisions will be populated with any keys that get overwritten
+func (e *Environ) Load(s store.Store, service string, collisions *[]string) error {
+	return e.load(s, service, collisions, false)
+}
+
+// LoadNoPaths is identical to Load, but uses v1-style "."-separated paths
+//
+// Deprecated like all noPaths functionality
+func (e *Environ) LoadNoPaths(s store.Store, service string, collisions *[]string) error {
+	return e.load(s, service, collisions, true)
+}

--- a/environ/environ.go
+++ b/environ/environ.go
@@ -3,7 +3,6 @@ package environ
 import (
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 )
 
@@ -54,7 +53,7 @@ func key(s string, noPaths bool) string {
 func (e *Environ) load(s store.Store, service string, collisions *[]string, noPaths bool) error {
 	rawSecrets, err := s.ListRaw(strings.ToLower(service))
 	if err != nil {
-		return errors.Wrap(err, "Failed to list store contents")
+		return err
 	}
 	envVarKeys := make([]string, 0)
 	for _, rawSecret := range rawSecrets {


### PR DESCRIPTION
I could have just copy-pasted this stuff, but there's a fair amount of fiddly details that I think could use capturing in their own exported library

This is for another docker entrypoint system that I'm working on that would work better if chamber weren't an extra binary.