### PR TITLE
Add `--pristine` to `exec` command

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -11,6 +11,9 @@ import (
 	analytics "gopkg.in/segmentio/analytics-go.v3"
 )
 
+// When true, only use variables retrieved from the backend, do not inherit existing environment variables
+var pristine bool
+
 // execCmd represents the exec command
 var execCmd = &cobra.Command{
 	Use:   "exec <service...> -- <command> [<arg...>]",
@@ -32,6 +35,7 @@ var execCmd = &cobra.Command{
 }
 
 func init() {
+	execCmd.Flags().BoolVar(&pristine, "pristine", false, "only use variables retrieved from the backend, do not inherit existing environment variables")
 	RootCmd.AddCommand(execCmd)
 }
 
@@ -51,7 +55,11 @@ func execRun(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	env := environ.Environ(os.Environ())
+	env := environ.Environ{}
+	if !pristine {
+		env = environ.Environ(os.Environ())
+	}
+
 	secretStore, err := getSecretStore()
 	if err != nil {
 		return errors.Wrap(err, "Failed to get secret store")


### PR DESCRIPTION
This adds the `--pristine` flag to only use secretes retrieved from the backend when launching the child process. This prevents leaking the host's environment to the child process.

We're using [envconsul](https://github.com/hashicorp/envconsul) at Splice and we want to move to chamber instead so we're porting the `--pristine` flag from `envconsul`. I really wish this could be the default behviour but it would break existing usage.

I'm not sure how to add tests for this. I didn't see any tests for the `exec` command.

One thing to mention is that `--pristine` will also remove the variables added by tools like `aws-vault` making it harder for dev environments. 

#### Keys in parameter store:

```
$ aws-vault exec dev -- ./chamber list service       
Key		Version		LastModified	User
db_host		1		11-20 10:45:23	arn:aws:iam::user
```

#### Without --pristine

```
$ aws-vault exec dev -- ./chamber exec service -- env
LANG=en_US.UTF-8
... a lot of env variables ...
DB_HOST=holi
```

#### With --pristine

```
$ aws-vault exec dev -- ./chamber exec service -- env
DB_HOST=holi
```
