### PR TITLE
add global --backend flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,13 +215,13 @@ If you'd like to use a custom SSM endpoint for chamber, you can use `CHAMBER_AWS
 
 By default, chamber store secrets in AWS Parameter Store.  We now also provide an experimental S3 backend for storing secrets in S3 instead.
 
-To configure chamber to use the S3 backend, set `CHAMBER_SECRET_BACKEND` to `s3://<bucket>`.  Preferably, this bucket should reject uploads that do not set the server side encryption header ([see this doc for details how](https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/))
+To configure chamber to use the S3 backend, use `chamber -b s3 --backend-s3-bucket=mybucket`.  Preferably, this bucket should reject uploads that do not set the server side encryption header ([see this doc for details how](https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/))
 
 This feature is experimental, and not currently meant for production work.
 
 ## Null Backend (experimental)
 
-If it's preferred to not use any backend at all, set `CHAMBER_SECRET_BACKEND` to `NULL`. Doing so will forward existing ENV variables as if Chamber is not in between.
+If it's preferred to not use any backend at all, use `chamber -b null`. Doing so will forward existing ENV variables as if Chamber is not in between.
 
 This feature is experimental, and not currently meant for production work.
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ If you'd like to use a custom SSM endpoint for chamber, you can use `CHAMBER_AWS
 
 By default, chamber store secrets in AWS Parameter Store.  We now also provide an experimental S3 backend for storing secrets in S3 instead.
 
-To configure chamber to use the S3 backend, set `CHAMBER_SECRET_BACKEND` to `S3`, and `CHAMBER_S3_BUCKET` to an existing S3 bucket.  Preferably, this bucket should reject uploads that do not set the server side encryption header ([see this doc for details how](https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/))
+To configure chamber to use the S3 backend, set `CHAMBER_SECRET_BACKEND` to `s3://<bucket>`.  Preferably, this bucket should reject uploads that do not set the server side encryption header ([see this doc for details how](https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/))
 
 This feature is experimental, and not currently meant for production work.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,8 +111,8 @@ func validateKey(key string) error {
 }
 
 func getSecretStore() (store.Store, error) {
-	// env var > flag > flag default
-	if backendEnvVarValue := os.Getenv(BackendEnvVar); backendEnvVarValue != "" {
+	rootPflags := RootCmd.PersistentFlags()
+	if backendEnvVarValue := os.Getenv(BackendEnvVar); !rootPflags.Changed("backend") && backendEnvVarValue != "" {
 		backend = backendEnvVarValue
 	} else {
 		backend = backendFlag
@@ -127,7 +127,7 @@ func getSecretStore() (store.Store, error) {
 		s = store.NewNullStore()
 	case S3Backend:
 		var bucket string
-		if bucketEnvVarValue := os.Getenv(BucketEnvVar); bucketEnvVarValue != "" {
+		if bucketEnvVarValue := os.Getenv(BucketEnvVar); !rootPflags.Changed("backend-s3-bucket") && bucketEnvVarValue != "" {
 			bucket = bucketEnvVarValue
 		} else {
 			bucket = backendS3BucketFlag


### PR DESCRIPTION
 `--backend` takes an option that is either a bare backend name like `ssm` or a URL like `s3://<bucket>`. I can imagine a world where it could take query options like `ssm://?use-v1-paths=1` instead of passing those by yet another env var*

This also extends the current `CHAMBER_SECRET_BACKEND` to allow for the URL syntax as well.

Besides that one, this gets us away from the proliferation of gross env vars. IMO env vars are just a bad UX vs flags. For one, none of our env vars are documented in the online help, only the README. This flag is documented in `--help`.

* This would require detangling the scattering of env vars all over the lib code base. I started trying to do that, but not sure it's worth the effort https://github.com/segmentio/chamber/pull/183