### PR TITLE
Add search command for SSM backend

### DIFF
--- a/cmd/list-services.go
+++ b/cmd/list-services.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// listServicesCmd represents the list command
+var listServicesCmd = &cobra.Command{
+	Use:   "list-services <service>",
+	Short: "List services",
+	RunE:  listServices,
+}
+
+var (
+	includeSecretName bool
+)
+
+func init() {
+	listServicesCmd.Flags().BoolVarP(&includeSecretName, "secrets", "s", false, "Include secret names in the list")
+	RootCmd.AddCommand(listServicesCmd)
+}
+
+func listServices(cmd *cobra.Command, args []string) error {
+	var service string
+	if len(args) == 0 {
+		service = ""
+	} else {
+		service = strings.ToLower(args[0])
+
+	}
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
+	secrets, err := secretStore.ListServices(service, includeSecretName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to list store contents")
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)
+	fmt.Fprint(w, "Service")
+	fmt.Fprintln(w, "")
+
+	sort.Strings(secrets)
+
+	for _, secret := range secrets {
+		fmt.Fprintf(w, "%s",
+			secret)
+		fmt.Fprintln(w, "")
+	}
+	w.Flush()
+	return nil
+}

--- a/store/nullstore.go
+++ b/store/nullstore.go
@@ -20,6 +20,10 @@ func (s *NullStore) Read(id SecretId, version int) (Secret, error) {
 	return Secret{}, errors.New("Not implemented for Null Store")
 }
 
+func (s *NullStore) ListServices(service string, includeSecretNames bool) ([]string, error) {
+	return nil, nil
+}
+
 func (s *NullStore) List(service string, includeValues bool) ([]Secret, error) {
 	return []Secret{}, nil
 }

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -178,6 +178,10 @@ func (s *S3Store) Read(id SecretId, version int) (Secret, error) {
 	}, nil
 }
 
+func (s *S3Store) ListServices(service string, includeSecretName bool) ([]string, error) {
+	return nil, fmt.Errorf("S3 Backend is experimental and does not implement this command")
+}
+
 func (s *S3Store) List(service string, includeValues bool) ([]Secret, error) {
 	index, err := s.readLatest(service)
 	if err != nil {

--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -143,6 +143,10 @@ func (s *S3KMSStore) Write(id SecretId, value string) error {
 	return s.writeLatest(id.Service, index)
 }
 
+func (s *S3KMSStore) ListServices(service string, includeSecretName bool) ([]string, error) {
+	return nil, fmt.Errorf("S3KMS Backend is experimental and does not implement this command")
+}
+
 func (s *S3KMSStore) List(service string, includeValues bool) ([]Secret, error) {
 	index, err := s.readLatest(service)
 	if err != nil {

--- a/store/shared.go
+++ b/store/shared.go
@@ -56,3 +56,17 @@ func getSession(numRetries int) (*session.Session, *string, error) {
 
 	return retSession, region, nil
 }
+
+func uniqueStringSlice(slice []string) []string {
+	unique := make(map[string]struct{}, len(slice))
+	j := 0
+	for _, value := range slice {
+		if _, ok := unique[value]; ok {
+			continue
+		}
+		unique[value] = struct{}{}
+		slice[j] = value
+		j++
+	}
+	return slice[:j]
+}

--- a/store/store.go
+++ b/store/store.go
@@ -63,6 +63,7 @@ type Store interface {
 	Read(id SecretId, version int) (Secret, error)
 	List(service string, includeValues bool) ([]Secret, error)
 	ListRaw(service string) ([]RawSecret, error)
+	ListServices(service string, includeSecretName bool) ([]string, error)
 	History(id SecretId) ([]ChangeEvent, error)
 	Delete(id SecretId) error
 }


### PR DESCRIPTION
This is a draft implementation of a search command.

In many cases we need to search for services and we have to fallback to `aws ssm` which is ok,
but it could be a good idea to implement this simple search functionality in `chamber`.


Let me know your thoughts and ill add the missing parts

### Example output
Service name: `servicename`
```
❯ awsve dev.admin -- dist/chamber-v2.3.3-pre2-5-g059f1d1-dev-linux-amd64 search /servicena  
Service
/servicename/secreta
/servicename/secretb
```

#### TODO

- [ ] Function/Method documentation
- [ ] Any required arguments?
- [ ] Implement S3
- [ ] Tests