### PR TITLE
feat(packagecloud): add ubuntu/cosmic + ubuntu/disco releases

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -15,7 +15,9 @@ PACKAGECLOUD_DEB_DISTROS := \
 	debian/stretch \
 	ubuntu/trusty \
 	ubuntu/xenial \
-	ubuntu/bionic
+	ubuntu/bionic \
+	ubuntu/cosmic \
+	ubuntu/disco
 
 PACKAGECLOUD_RPM_DISTROS := \
 	fedora/27 \


### PR DESCRIPTION
These 2 versions of Ubuntu are out and currently supported, though they are not LTS versions. I recently upgraded from Bionic (current LTS) through Cosmic and to Disco and the PPA for chamber stopped working as a result.

After this is merged, we should tag a new release.