### PR TITLE
update date format to include year

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ var (
 
 const (
 	// ShortTimeFormat is a short format for printing timestamps
-	ShortTimeFormat = "01-02 15:04:05"
+	ShortTimeFormat = "2018-01-02 15:04:05"
 
 	// DefaultNumRetries is the default for the number of retries we'll use for our SSM client
 	DefaultNumRetries = 10

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ var (
 
 const (
 	// ShortTimeFormat is a short format for printing timestamps
-	ShortTimeFormat = "2018-01-02 15:04:05"
+	ShortTimeFormat = "2006-01-02 15:04:05"
 
 	// DefaultNumRetries is the default for the number of retries we'll use for our SSM client
 	DefaultNumRetries = 10


### PR DESCRIPTION
Currently, the date format printed to STDOUT only includes the month and day. This change adds the year to the date format.