### PR TITLE
feat: Add `find` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ $ chamber delete service key
 including the secret's additional metadata. There is no way to recover a
 secret once it has been deleted so care should be taken with this command.
 
+### Finding
+```bash
+$ chamber find key
+```
+
+`find` provides the ability to locate which services use the same key names.
+
+```bash
+$ chamber find value --by-value
+```
+Passing `--by-value` or `-v` will search the values of all secrets and return
+the services and keys which match.
+
 ### AWS Region
 
 Chamber uses [AWS SDK for Go](https://github.com/aws/aws-sdk-go). To use a

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/chamber/store"
+	"github.com/spf13/cobra"
+)
+
+// findCmd represents the find command
+var findCmd = &cobra.Command{
+	Use:   "find <secret name>",
+	Short: "Find the given secret across all services",
+	Args:  cobra.ExactArgs(1),
+	RunE:  find,
+}
+
+var (
+	blankService   string
+	byValue        bool
+	includeSecrets bool
+	matches        []store.SecretId
+)
+
+func init() {
+	findCmd.Flags().BoolVarP(&byValue, "by-value", "v", false, "Find parameters by value")
+	RootCmd.AddCommand(findCmd)
+}
+
+func find(cmd *cobra.Command, args []string) error {
+	findSecret := args[0]
+
+	if byValue {
+		includeSecrets = false
+	} else {
+		includeSecrets = true
+	}
+
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
+	services, err := secretStore.ListServices(blankService, includeSecrets)
+	if err != nil {
+		return errors.Wrap(err, "Failed to list store contents")
+	}
+
+	if byValue {
+		for _, service := range services {
+			allSecrets, err := secretStore.List(service, true)
+			if err == nil {
+				matches = append(matches, findValueMatch(allSecrets, findSecret)...)
+			}
+		}
+	} else {
+		matches = append(matches, findKeyMatch(services, findSecret)...)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)
+	fmt.Fprint(w, "Service")
+	if byValue {
+		fmt.Fprint(w, "\tKey")
+	}
+	fmt.Fprintln(w, "")
+
+	for _, match := range matches {
+		fmt.Fprintf(w, "%s", match.Service)
+		if byValue {
+			fmt.Fprintf(w, "\t%s", match.Key)
+		}
+		fmt.Fprintln(w, "")
+	}
+	w.Flush()
+
+	return nil
+}
+
+func findKeyMatch(services []string, searchTerm string) []store.SecretId {
+	keyMatches := []store.SecretId{}
+
+	for _, service := range services {
+		if searchTerm == key(service) {
+
+			keyMatches = append(keyMatches, store.SecretId{
+				Service: path(service),
+				Key:     key(service),
+			})
+		}
+	}
+	return keyMatches
+}
+
+func findValueMatch(secrets []store.Secret, searchTerm string) []store.SecretId {
+	valueMatches := []store.SecretId{}
+
+	for _, secret := range secrets {
+		if *secret.Value == searchTerm {
+			valueMatches = append(valueMatches, store.SecretId{
+				Service: path(secret.Meta.Key),
+				Key:     key(secret.Meta.Key),
+			})
+		}
+	}
+	return valueMatches
+}
+
+func path(s string) string {
+	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
+	sep := "/"
+	if noPaths {
+		sep = "."
+	}
+
+	tokens := strings.Split(s, sep)
+	secretPath := strings.Join(tokens[1:len(tokens)-1], "/")
+	return secretPath
+}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -1,0 +1,250 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/segmentio/chamber/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindFunctions(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		output string
+	}{
+		{
+			"service1",
+			"/service1/key_one",
+			"service1",
+		},
+		{
+			"service2",
+			"/service2/subService/key_two",
+			"service2/subService",
+		},
+		{
+			"service3",
+			"/service3/subService/subSubService/key_three",
+			"service3/subService/subSubService",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := path(test.params)
+			assert.Equal(t, test.output, result)
+		})
+	}
+
+	keyMatchTests := []struct {
+		name       string
+		services   []string
+		searchTerm string
+		output     []store.SecretId
+	}{
+		{
+			"findNoMatches",
+			[]string{"/service1/launch_darkly_key",
+				"/service2/s3_bucket_base",
+				"/service3/slack_token",
+			},
+			"s3_bucket",
+			[]store.SecretId{},
+		},
+		{
+			"findSomeMatches",
+			[]string{"/service1/s3_bucket",
+				"/service2/s3_bucket_base",
+				"/service3/s3_bucket",
+			},
+			"s3_bucket",
+			[]store.SecretId{
+				{
+					"service1",
+					"s3_bucket",
+				},
+				{
+					"service3",
+					"s3_bucket",
+				},
+			},
+		},
+		{
+			"findEverythingMatches",
+			[]string{"/service1/s3_bucket",
+				"/service2/s3_bucket",
+				"/service3/s3_bucket",
+			},
+			"s3_bucket",
+			[]store.SecretId{
+				{
+					"service1",
+					"s3_bucket",
+				},
+				{
+					"service2",
+					"s3_bucket",
+				},
+				{
+					"service3",
+					"s3_bucket",
+				},
+			},
+		},
+	}
+
+	for _, test := range keyMatchTests {
+		t.Run(test.name, func(t *testing.T) {
+			result := findKeyMatch(test.services, test.searchTerm)
+			fmt.Println(result)
+			assert.Equal(t, test.output, result)
+		})
+	}
+
+	valueDarklyToken := "1@m@Pr3t3ndL@unchD@rkl3yK3y"
+	valueSlackToken := "1@m@Pr3t3ndSlackToken"
+	valueGoodS3Bucket := "s3://this_bucket"
+	valueBadS3Bucket := "s3://not_your_bucket"
+
+	valueMatchTests := []struct {
+		name       string
+		secrets    []store.Secret
+		searchTerm string
+		output     []store.SecretId
+	}{
+		{
+			"findNoMatches",
+			[]store.Secret{
+				store.Secret{
+					&valueDarklyToken,
+					store.SecretMetadata{
+						time.Now(),
+						"no one",
+						0,
+						"/service1/launch_darkly_key",
+					},
+				},
+				store.Secret{
+					&valueSlackToken,
+					store.SecretMetadata{
+						time.Now(),
+						"no one",
+						0,
+						"/service1/slack_token",
+					},
+				},
+				store.Secret{
+					&valueBadS3Bucket,
+					store.SecretMetadata{
+						time.Now(),
+						"no one",
+						0,
+						"/service1/s3_bucket",
+					},
+				},
+			},
+			"s3://this_bucket",
+			[]store.SecretId{},
+		},
+		{
+			"findSomeMatches",
+			[]store.Secret{
+				store.Secret{
+					&valueDarklyToken,
+					store.SecretMetadata{
+						time.Now(),
+						"no one",
+						0,
+						"/service1/launch_darkly_key",
+					},
+				},
+				store.Secret{
+					&valueGoodS3Bucket,
+					store.SecretMetadata{
+						time.Now(),
+						"no one",
+						0,
+						"/service1/s3_bucket_name",
+					},
+				},
+				store.Secret{
+					&valueGoodS3Bucket,
+					store.SecretMetadata{
+						time.Now(),
+						"no one",
+						0,
+						"/service1/s3_bucket",
+					},
+				},
+			},
+			"s3://this_bucket",
+			[]store.SecretId{
+				{
+					"service1",
+					"s3_bucket_name",
+				},
+				{
+					"service1",
+					"s3_bucket",
+				},
+			},
+		},
+		{
+			"findEverythingMatches",
+			[]store.Secret{
+				store.Secret{
+					&valueGoodS3Bucket,
+					store.SecretMetadata{
+						time.Now(),
+						"no one",
+						0,
+						"/service1/s3_bucket_base",
+					},
+				},
+				store.Secret{
+					&valueGoodS3Bucket,
+					store.SecretMetadata{
+						time.Now(),
+						"no one",
+						0,
+						"/service1/s3_bucket_name",
+					},
+				},
+				store.Secret{
+					&valueGoodS3Bucket,
+					store.SecretMetadata{
+						time.Now(),
+						"no one",
+						0,
+						"/service1/s3_bucket",
+					},
+				},
+			},
+			"s3://this_bucket",
+			[]store.SecretId{
+				{
+					"service1",
+					"s3_bucket_base",
+				},
+				{
+					"service1",
+					"s3_bucket_name",
+				},
+				{
+					"service1",
+					"s3_bucket",
+				},
+			},
+		},
+	}
+
+	for _, test := range valueMatchTests {
+		t.Run(test.name, func(t *testing.T) {
+			result := findValueMatch(test.secrets, test.searchTerm)
+			assert.Equal(t, test.output, result)
+		})
+	}
+
+}


### PR DESCRIPTION
In response to https://github.com/segmentio/chamber/issues/221

This adds a `find` command to chamber which can be used to find similar Keys in a store.

```
$ chamber find -h
Find the given secret across all services

Usage:
  chamber find <secret> [flags]

Flags:
  -v, --by-value   Find parameters by value
  -h, --help       help for find
```
```
$ chamber find s3_bucket_name
Service
service1
service2
service5
```
```
$ chamber find s3://this_bucket --by-value
Service				Key
service1			s3_bucket_name
service2			s3_bucket_name
service3			s3_bucket
service4			s3_bucket_base
service5			s3_bucket_name
```