### PR TITLE
pipeline: publish to docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
       - run:
           name: Release
           command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
             make -f Makefile.release publish-dockerhub
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,17 @@ jobs:
           command: |
             make -f Makefile.release publish-github
 
+  publish-dockerhub:
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - checkout
+      - attach_workspace: { at: . }
+      - run:
+          name: Release
+          command: |
+            make -f Makefile.release publish-dockerhub
+
 workflows:
   version: 2
   test-dist-publish:
@@ -120,6 +131,17 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*(-[a-zA-Z0-9-]+)?/
       - publish-github:
           context: github-segmentcircle-oss-release
+          requires:
+            - dist
+          filters:
+            # never publish from a branch event
+            branches:
+              ignore: /.*/
+            # release only on tag push events like vX[.Y.Z...][-whatever]
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-[a-zA-Z0-9-]+)?/
+      - publish-dockerhub:
+          context: docker-publish
           requires:
             - dist
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: { at: . }
+      - setup_remote_docker
       - run:
           name: Release
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine AS build
+FROM golang:1.13-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # This makefile is meant for humans
 
 VERSION := $(shell git describe --tags --always --dirty="-dev")
+VERSION_NO_V := $(shell git describe --tags --always --dirty="-dev" | sed 's/^v//')
 VERSION_MAJOR_MINOR_PATCH := $(shell git describe --tags --always --dirty="-dev" | sed 's/^v\([0-9]*.[0-9]*.[0-9]*\).*/\1/')
 VERSION_MAJOR_MINOR := $(shell git describe --tags --always --dirty="-dev" | sed 's/^v\([0-9]*.[0-9]*\).*/\1/')
 VERSION_MAJOR := $(shell git describe --tags --always --dirty="-dev" | sed 's/^v\([0-9]*\).*/\1/')
@@ -39,18 +40,4 @@ dist/chamber-$(VERSION)-linux-amd64: | dist/
 dist/chamber-$(VERSION)-windows-amd64.exe: | dist/
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -mod=vendor $(LDFLAGS) -o $@
 
-docker-image: docker-image-$(VERSION)
-
-docker-image-$(VERSION):
-	docker build \
-		-t segment/chamber:$(VERSION_MAJOR_MINOR_PATCH) \
-		-t segment/chamber:$(VERSION_MAJOR_MINOR) \
-		-t segment/chamber:$(VERSION_MAJOR) \
-		.
-
-docker-image-publish: docker-image
-	docker push segment/chamber:$(VERSION_MAJOR_MINOR_PATCH)
-	docker push segment/chamber:$(VERSION_MAJOR_MINOR)
-	docker push segment/chamber:$(VERSION_MAJOR)
-
-.PHONY: clean all linux docker-image docker-image-$(VERSION) docker-image-publish build
+.PHONY: clean all linux

--- a/Makefile.release
+++ b/Makefile.release
@@ -9,6 +9,7 @@ include Makefile
 ifneq (,$(findstring -,$(VERSION)))
 	GITHUB_RELEASE_FLAGS := "--pre-release"
 	PACKAGECLOUD_NAME_SUFFIX := "-prerelease"
+	DOCKERHUB_TAG_PREFIX := "prerelease-"
 endif
 
 PACKAGECLOUD_DEB_DISTROS := \
@@ -110,6 +111,18 @@ publish-packagecloud-rpm: dist/chamber_$(VERSION)_amd64.rpm packagecloud.conf.js
 			grep -v 'with token:' ; \
 	done
 
+publish-dockerhub:
+	docker build \
+		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR_PATCH) \
+		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR) \
+		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR) \
+		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_NO_V) \
+		.
+	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR_PATCH)
+	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR)
+	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR)
+	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_NO_V)
+
 dist: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber-$(VERSION)-windows-amd64.exe dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm dist/chamber-$(VERSION).sha256sums
 
 dist/chamber-$(VERSION).sha256sums: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber-$(VERSION)-windows-amd64.exe dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm
@@ -131,4 +144,5 @@ dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml dist/chamber-$(VERS
 	publish-github-rpm \
 	publish-github-deb \
 	publish-github-darwin \
+	publish-dockerhub \
 	github-release


### PR DESCRIPTION
E.g., for v2.3.1, publish :2.3.1 :2.3 :2
For v2.3.1-pre1, publish :prerelease-2.3.1-pre1 :prerelease-2.3 :prerelease-2

The prereleases like :prerelease-2 could be any old trash, but this helps us test the pipeline.

Also fixes dockerfile to use golang1.13