### PR TITLE
fix: Implements ListRaw required for export from S3-KMS store

### DIFF
--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -188,6 +188,25 @@ func (s *S3KMSStore) List(service string, includeValues bool) ([]Secret, error) 
 	return secrets, nil
 }
 
+func (s *S3KMSStore) ListRaw(service string) ([]RawSecret, error) {
+
+	secretList, err := s.List(service, true)
+	if err != nil {
+		return []RawSecret{}, err
+	}
+
+	secrets := []RawSecret{}
+	for _, secret := range secretList {
+		s := RawSecret{
+			Key:   fmt.Sprintf("/%s/%s", service, secret.Meta.Key),
+			Value: *secret.Value,
+		}
+		secrets = append(secrets, s)
+	}
+
+	return secrets, nil
+}
+
 func (s *S3KMSStore) Delete(id SecretId) error {
 	index, err := s.readLatest(id.Service)
 	if err != nil {


### PR DESCRIPTION
I noticed that the `export` implementation uses `ListRaw` to iterate over the secrets in the store and return them in the requested format, while the `env` functionality uses `List`. `ListRaw` was not included in #195 which implements the S3-KMS backend, so the `env` command works correctly, but `export`, which is more flexible, does not. This PR rectifies this so that `export` will work correctly. 