### PR TITLE
Read command -- don't lowercase keys

### DIFF
--- a/cmd/read.go
+++ b/cmd/read.go
@@ -37,7 +37,7 @@ func read(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
-	key := strings.ToLower(args[1])
+	key := args[1]
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")
 	}


### PR DESCRIPTION
#### For the `read` subcommand

`service` makes sense to lowercase
`key` does not

Forcing the `key` to lowercase means it's impossible to read an all-caps key. This does not makes sense to me. Most ENV vars are uppercase.

#### Evidence that this is a unhelpful default:

#219
#160 