### PR TITLE
Label support for SSMStore

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -87,7 +87,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, service := range services {
-		if err := validateService(service); err != nil {
+		if err := validateServiceWithLabel(service); err != nil {
 			return errors.Wrap(err, "Failed to validate service")
 		}
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -38,7 +38,7 @@ func init() {
 
 func list(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
-	if err := validateService(service); err != nil {
+	if err := validateServiceWithLabel(service); err != nil {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,9 +14,11 @@ import (
 
 // Regex's used to validate service and key names
 var (
-	validKeyFormat         = regexp.MustCompile(`^[\w\-\.]+$`)
-	validServiceFormat     = regexp.MustCompile(`^[\w\-\.]+$`)
-	validServicePathFormat = regexp.MustCompile(`^[\w\-\.]+(\/[\w\-\.]+)*$`)
+	validKeyFormat                  = regexp.MustCompile(`^[\w\-\.]+$`)
+	validServiceFormat              = regexp.MustCompile(`^[\w\-\.]+$`)
+	validServicePathFormat          = regexp.MustCompile(`^[\w\-\.]+(\/[\w\-\.]+)*$`)
+	validServiceFormatWithLabel     = regexp.MustCompile(`^[\w\-\.\:]+$`)
+	validServicePathFormatWithLabel = regexp.MustCompile(`^[\w\-\.]+(\/[\w\-\.]+)+(\:[\w\-\.]+)*$`)
 
 	verbose        bool
 	numRetries     int
@@ -104,6 +106,21 @@ func validateService(service string) error {
 	} else {
 		if !validServicePathFormat.MatchString(service) {
 			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, forwardslashes, fullstops and underscores are allowed for service names", service)
+		}
+	}
+
+	return nil
+}
+
+func validateServiceWithLabel(service string) error {
+	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
+	if noPaths {
+		if !validServiceFormatWithLabel.MatchString(service) {
+			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, fullstops and underscores are allowed for service names, and colon followed by a label name", service)
+		}
+	} else {
+		if !validServicePathFormatWithLabel.MatchString(service) {
+			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, forwardslashes, fullstops and underscores are allowed for service names, and colon followed by a label name", service)
 		}
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -107,4 +107,35 @@ func TestValidations(t *testing.T) {
 		})
 	}
 	os.Unsetenv("CHAMBER_NO_PATHS")
+
+	// Test Service format with PATH and Label
+	validServicePathFormatWithLabel := []string{
+		"foo/bar:-current-",
+		"foo.bar/foo:current",
+		"foo-bar/foo:current",
+		"foo-bar/foo-bar:current",
+		"foo/bar/foo:current",
+		"foo/bar/foo-bar:current",
+		"foo/bar/foo-bar",
+	}
+
+	for _, k := range validServicePathFormatWithLabel {
+		t.Run("Service with PATH validation and label should return Nil", func(t *testing.T) {
+			result := validateServiceWithLabel(k)
+			assert.Nil(t, result)
+		})
+	}
+
+	invalidServicePathFormatWithLabel := []string{
+		"foo:current$",
+		"foo.:",
+		"foo.bar:cur|rent",
+	}
+
+	for _, k := range invalidServicePathFormatWithLabel {
+		t.Run("Service with PATH validation and label should return Error", func(t *testing.T) {
+			result := validateServiceWithLabel(k)
+			assert.Error(t, result)
+		})
+	}
 }

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -583,10 +583,10 @@ func parseServiceLabel(serviceAndLabel string) (string, string) {
 			service := serviceAndLabel[:i]
 			label := serviceAndLabel[i+1:]
 			return service, label
-		} else {
-			return serviceAndLabel, ""
 		}
-	} else {
+
 		return serviceAndLabel, ""
 	}
+
+	return serviceAndLabel, ""
 }

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -855,21 +855,6 @@ func TestValidations(t *testing.T) {
 			assert.Equal(t, label, k[2])
 		})
 	}
-
-	// invalidPathWithLabelFormat := []string{
-	// "/foo//bar:current",
-	// "foo//bar:blue",
-	// "foo/bar:green",
-	// "foo/b:v10",
-	// "foo:current",
-	// }
-	//
-	// for _, k := range invalidPathWithLabelFormat {
-	// t.Run("Path Validation with Label should return false", func(t *testing.T) {
-	// result := parseServiceLabel(k)
-	// assert.False(t, result)
-	// })
-	// }
 }
 
 type ByKey []Secret

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -831,6 +831,45 @@ func TestValidations(t *testing.T) {
 			assert.False(t, result)
 		})
 	}
+
+	// Valid Path with Label
+	validPathWithLabelFormat := [][]string{
+		{"/foo", "/foo", ""},
+		{"/foo.", "/foo.", ""},
+		{"/foo.", "/foo.", ""},
+		{"/.foo:blue", "/.foo", "blue"},
+		{"/foo.bar:v30", "/foo.bar", "v30"},
+		{"/foo-bar:v90", "/foo-bar", "v90"},
+		{"/foo/bar:current", "/foo/bar", "current"},
+		{"/foo.bar/foo:yellow", "/foo.bar/foo", "yellow"},
+		{"/foo-bar/foo:v30:current", "/foo-bar/foo", "v30:current"},
+		{"/foo-bar/foo-bar:v10", "/foo-bar/foo-bar", "v10"},
+		{"/foo/bar/foo:90", "/foo/bar/foo", "90"},
+		{"/foo/bar/foo-bar:90-10", "/foo/bar/foo-bar", "90-10"},
+	}
+
+	for _, k := range validPathWithLabelFormat {
+		t.Run("Path Validation with Label should return true", func(t *testing.T) {
+			result, label := parseServiceLabel(k[0])
+			assert.Equal(t, result, k[1])
+			assert.Equal(t, label, k[2])
+		})
+	}
+
+	// invalidPathWithLabelFormat := []string{
+	// "/foo//bar:current",
+	// "foo//bar:blue",
+	// "foo/bar:green",
+	// "foo/b:v10",
+	// "foo:current",
+	// }
+	//
+	// for _, k := range invalidPathWithLabelFormat {
+	// t.Run("Path Validation with Label should return false", func(t *testing.T) {
+	// result := parseServiceLabel(k)
+	// assert.False(t, result)
+	// })
+	// }
 }
 
 type ByKey []Secret


### PR DESCRIPTION
Added support for SSMStore. Format: `/foo:v1`, `/foo` service, `v1` is the label. This is backwards compatible and does not break existing API.