### PR TITLE
docs: add secret key normalization rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ key already exists, it will increment the version and store a new value.
 If `-` is provided as the value argument, the value will be read from standard
 input.
 
+Secret keys are normalized automatically. The `-` will be `_` and the letters will be converted to upper case (for example a secret with key `secret_key` and `secret-key` will become `SECRET_KEY`).
 
 ### Listing Secrets
 


### PR DESCRIPTION
**Context**
There is no section that explains the secret key normalization rule:
1. Uppercase
2. `-` will become `_`

It caused a lot of developers to debug this issue during developing an application unless they saw the source codes https://github.com/segmentio/chamber/blob/master/environ/environ.go#L82-L84

**Changes**
Added a section to explain that rules so developers will be aware of this rule before deploying their applications into production using chamber even without seeing the source codes