### PR TITLE
fix: bad regex regression introduced by #242

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ var (
 	validServiceFormat              = regexp.MustCompile(`^[\w\-\.]+$`)
 	validServicePathFormat          = regexp.MustCompile(`^[\w\-\.]+(\/[\w\-\.]+)*$`)
 	validServiceFormatWithLabel     = regexp.MustCompile(`^[\w\-\.\:]+$`)
-	validServicePathFormatWithLabel = regexp.MustCompile(`^[\w\-\.]+(\/[\w\-\.]+)+(\:[\w\-\.]+)*$`)
+	validServicePathFormatWithLabel = regexp.MustCompile(`^[\w\-\.]+((\/[\w\-\.]+)+(\:[\w\-\.]+)*)?$`)
 
 	verbose        bool
 	numRetries     int

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -110,6 +110,7 @@ func TestValidations(t *testing.T) {
 
 	// Test Service format with PATH and Label
 	validServicePathFormatWithLabel := []string{
+		"foo",
 		"foo/bar:-current-",
 		"foo.bar/foo:current",
 		"foo-bar/foo:current",


### PR DESCRIPTION
Fixes #245 by making the path/label optional in the regex.
Added test coverage of the specific scenario reported in #242 