### PR TITLE
Ignore .git in images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.github
+.circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 ARG VERSION
 RUN test -n "${VERSION}"
 
-RUN apk add -U make git
+RUN apk add -U make
 RUN make linux VERSION=${VERSION}
 
 FROM scratch AS run

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM golang:1.13-alpine AS build
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .
 
+ARG VERSION
+RUN test -n "${VERSION}"
+
 RUN apk add -U make git
-RUN make linux
+RUN make linux VERSION=${VERSION}
 
 FROM scratch AS run
 

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,14 @@
 #
 # This makefile is meant for humans
 
-VERSION := $(shell git describe --tags --always --dirty="-dev")
-VERSION_NO_V := $(shell git describe --tags --always --dirty="-dev" | sed 's/^v//')
-VERSION_MAJOR_MINOR_PATCH := $(shell git describe --tags --always --dirty="-dev" | sed 's/^v\([0-9]*.[0-9]*.[0-9]*\).*/\1/')
-VERSION_MAJOR_MINOR := $(shell git describe --tags --always --dirty="-dev" | sed 's/^v\([0-9]*.[0-9]*\).*/\1/')
-VERSION_MAJOR := $(shell git describe --tags --always --dirty="-dev" | sed 's/^v\([0-9]*\).*/\1/')
+ifndef VERSION
+	VERSION := $(shell git describe --tags --always --dirty="-dev")
+endif
+
+VERSION_NO_V := $(shell echo "$(VERSION)" | sed 's/^v//')
+VERSION_MAJOR_MINOR_PATCH := $(shell echo "$(VERSION)" | sed 's/^v\([0-9]*.[0-9]*.[0-9]*\).*/\1/')
+VERSION_MAJOR_MINOR := $(shell echo "$(VERSION)" | sed 's/^v\([0-9]*.[0-9]*\).*/\1/')
+VERSION_MAJOR := $(shell echo "$(VERSION)" | sed 's/^v\([0-9]*\).*/\1/')
 ANALYTICS_WRITE_KEY ?=
 LDFLAGS := -ldflags='-X "main.Version=$(VERSION)" -X "main.AnalyticsWriteKey=$(ANALYTICS_WRITE_KEY)"'
 

--- a/Makefile.release
+++ b/Makefile.release
@@ -127,6 +127,7 @@ publish-dockerhub:
 		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR) \
 		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR) \
 		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_NO_V) \
+		--build-arg VERSION=$(VERSION) \
 		.
 	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR_PATCH)
 	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR)


### PR DESCRIPTION
## Description
This change adds a `.dockerignore` file to this repo that explicitly ignores `.git` and other, potentially sensitive directories. To keep the versioning logic (which depends on git) working in `docker build` steps, it passes the version in to docker instead of generating it during the image build process.