### PR TITLE
WIP: Adding include feature to chamber

### DIFF
--- a/cmd/include.go
+++ b/cmd/include.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/chamber/v2/store"
+	"github.com/spf13/cobra"
+)
+
+var (
+	includeCmd = &cobra.Command{
+		Use:   "include <service> <another-service>",
+		Short: "create a run-time include. see documentation",
+		Args:  cobra.ExactArgs(2),
+		RunE:  include,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(includeCmd)
+}
+
+func include(cmd *cobra.Command, args []string) error {
+	service := strings.ToLower(args[0])
+	if err := validateService(service); err != nil {
+		return errors.Wrap(err, "Failed to validate service")
+	}
+
+	includeService := strings.ToLower(args[1])
+	if err := validateService(includeService); err != nil {
+		return errors.Wrap(err, "Failed to validate service to import")
+	}
+
+	secretStore, err := getSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get secret store")
+	}
+
+	secretId := store.SecretId{
+		Service: service,
+		Key:     fmt.Sprintf("chamber-include-%s", includeService),
+	}
+
+	return secretStore.WriteInclude(secretId, includeService)
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -83,8 +83,14 @@ func list(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, secret := range secrets {
+		secretKey := key(secret.Meta.Key)
+		secretService := serviceFromKey(secret.Meta.Key)
+		if secretService != service {
+			secretKey = fmt.Sprintf("%s (%s)", secretKey, secretService)
+		}
+
 		fmt.Fprintf(w, "%s\t%d\t%s\t%s",
-			key(secret.Meta.Key),
+			key(secretKey),
 			secret.Meta.Version,
 			secret.Meta.Created.Local().Format(ShortTimeFormat),
 			secret.Meta.CreatedBy)
@@ -96,6 +102,18 @@ func list(cmd *cobra.Command, args []string) error {
 
 	w.Flush()
 	return nil
+}
+
+func serviceFromKey(s string) string {
+	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
+	sep := "/"
+	if noPaths {
+		sep = "."
+	}
+
+	tokens := strings.Split(s, sep)
+	secretService := tokens[len(tokens)-2]
+	return secretService
 }
 
 func key(s string) string {

--- a/store/nullstore.go
+++ b/store/nullstore.go
@@ -16,6 +16,10 @@ func (s *NullStore) Write(id SecretId, value string) error {
 	return errors.New("Write is not implemented for Null Store")
 }
 
+func (s *NullStore) WriteInclude(id SecretId, includeService string) error {
+	return errors.New("WriteInclude is not implemented for Null Store")
+}
+
 func (s *NullStore) Read(id SecretId, version int) (Secret, error) {
 	return Secret{}, errors.New("Not implemented for Null Store")
 }

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -147,6 +148,10 @@ func (s *S3Store) Write(id SecretId, value string) error {
 
 	index.Latest[id.Key] = value
 	return s.writeLatest(id.Service, index)
+}
+
+func (s *S3Store) WriteInclude(id SecretId, service string) error {
+	return errors.New("WriteInclude is not implemented for S3 Store")
 }
 
 func (s *S3Store) Read(id SecretId, version int) (Secret, error) {

--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -143,6 +143,10 @@ func (s *S3KMSStore) Write(id SecretId, value string) error {
 	return s.writeLatest(id.Service, index)
 }
 
+func (s *S3KMSStore) WriteInclude(id SecretId, service string) error {
+	return errors.New("WriteInclude is not supported for the S3KMS Store")
+}
+
 func (s *S3KMSStore) ListServices(service string, includeSecretName bool) ([]string, error) {
 	return nil, fmt.Errorf("S3KMS Backend is experimental and does not implement this command")
 }

--- a/store/secretsmanagerstore.go
+++ b/store/secretsmanagerstore.go
@@ -3,6 +3,7 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -222,6 +223,10 @@ func (s *SecretsManagerStore) Write(id SecretId, value string) error {
 	}
 
 	return nil
+}
+
+func (s *SecretsManagerStore) WriteInclude(id SecretId, service string) error {
+	return errors.New("WriteImport is not supported by SecretsManagerStore")
 }
 
 // Read reads a secret at a specific version.

--- a/store/store.go
+++ b/store/store.go
@@ -44,11 +44,16 @@ type RawSecret struct {
 	Key   string
 }
 
+type ServiceMetadata struct {
+	IncludedServices []string `json:"includes"`
+}
+
 type SecretMetadata struct {
-	Created   time.Time
-	CreatedBy string
-	Version   int
-	Key       string
+	Created      time.Time
+	CreatedBy    string
+	Version      int
+	Key          string
+	ImportedFrom string
 }
 
 type ChangeEvent struct {
@@ -61,6 +66,7 @@ type ChangeEvent struct {
 type Store interface {
 	Write(id SecretId, value string) error
 	Read(id SecretId, version int) (Secret, error)
+	WriteInclude(id SecretId, serviceToInclude string) error
 	List(service string, includeValues bool) ([]Secret, error)
 	ListRaw(service string) ([]RawSecret, error)
 	ListServices(service string, includeSecretName bool) ([]string, error)


### PR DESCRIPTION
**Use Case**
We have several services which have to use some secrets which are duplicated around.  Wanted to create an ability for a secret store to include other secret stores at runtime. This will reduce duplication of secrets and allow separate groups to manage sets of secrets via IAM roles.

**Proposed Solution**
Add new feature for the Secret Store interface for WriteInclude, RemoveInclude. Leave it up to the store on exact method of implementation, but any secret stores mentioned in the includes should be brought back by Read/List/ListRaw methods.

Implement a new type of ServiceMetadata to hold processing instructions for a particular service. 

**SSM Store Support for Includes**
Adding SSM store support for includes. Implemented by using a 'metadata' key in ParaemterStore that will be used to house any operational info about a service. The metadata is optional and only exists when the WriteInclude function is called for the service. If the metadata does not exist, the program will continue without error. 

The metadata includes a property "IncludedServices" which is a string[] of services to include. Upon reading/listing secrets for a service, a recursive call with the included service will be made to include secrets. Currently no check/limitation on included secrets.

**List command updated to reflect service**
If a particular key does not directly live under the service for which List was called, it will return the owning service name in parenthesis as an indicator that it is owned/maintained in another service.

**Open Issues/Questions**

- How should export function handle secrets?
- Guard against cyclical dependencies (Service A -> Service B -> Service A)
- Implement other functions