### PR TITLE
pipeline: remove release context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,8 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-[a-zA-Z0-9-]+)?/
       - publish-github:
-          context: github-segmentcircle-oss-release
+          # we don't need a context for this one; we've got a specific PAT in
+          # our GH_LOGIN env var
           requires:
             - dist
           filters:


### PR DESCRIPTION
we're switching tokens/users for doing releases. I've added the PAT as an env var in Circle.