### PR TITLE
Fix go 1.15 build

### DIFF
--- a/store/secretsmanagerstore.go
+++ b/store/secretsmanagerstore.go
@@ -213,7 +213,7 @@ func (s *SecretsManagerStore) Write(id SecretId, value string) error {
 		putSecretValueInput := &secretsmanager.PutSecretValueInput{
 			SecretId:      aws.String(id.Service),
 			SecretString:  aws.String(string(contents)),
-			VersionStages: []*string{aws.String("AWSCURRENT"), aws.String("CHAMBER" + string(version))},
+			VersionStages: []*string{aws.String("AWSCURRENT"), aws.String("CHAMBER" + fmt.Sprint(version))},
 		}
 		_, err = s.svc.PutSecretValue(putSecretValueInput)
 		if err != nil {


### PR DESCRIPTION
Fix as suggested by error message

```
# github.com/segmentio/chamber/v2/store
store/secretsmanagerstore.go:216:78: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL    github.com/segmentio/chamber/v2/store [build failed]
```