### PR TITLE
Optimise ListRaw for S3-KMS backend

### DIFF
--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -189,17 +189,17 @@ func (s *S3KMSStore) List(service string, includeValues bool) ([]Secret, error) 
 }
 
 func (s *S3KMSStore) ListRaw(service string) ([]RawSecret, error) {
-
-	secretList, err := s.List(service, true)
+	index, err := s.readLatest(service)
 	if err != nil {
 		return []RawSecret{}, err
 	}
 
+	// Read raw secrets directly from the index file (which caches the latest values)
 	secrets := []RawSecret{}
-	for _, secret := range secretList {
+	for key := range index.Latest {
 		s := RawSecret{
-			Key:   fmt.Sprintf("/%s/%s", service, secret.Meta.Key),
-			Value: *secret.Value,
+			Key:   fmt.Sprintf("/%s/%s", service, key),
+			Value: index.Latest[key].Value,
 		}
 		secrets = append(secrets, s)
 	}

--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -188,6 +188,9 @@ func (s *S3KMSStore) List(service string, includeValues bool) ([]Secret, error) 
 	return secrets, nil
 }
 
+// ListRaw returns RawSecrets by extracting them from the index file. It only ever uses the 
+// index file; it never consults the actual secrets, so if the index file is out of sync, these
+// results will reflect that.
 func (s *S3KMSStore) ListRaw(service string) ([]RawSecret, error) {
 	index, err := s.readLatest(service)
 	if err != nil {


### PR DESCRIPTION
We've started using `chamber exec` in some interactive CLI tools and noticed that it was quite slow in many cases. This is because the S3 KMS backend was making an unnecessary request for each secret, in addition to fetching all of the secrets in one go via the index file.

`ListRaw` was originally implented as a wrapper for `List` in https://github.com/segmentio/chamber/pull/236. This is unnecessarily slow, since `ListRaw` doesn't need any of the additional info about each secret provided by `List`. Now, `ListRaw` doesn't call `List`; instead, it just pulls the data it needs straight from the index file.

This reduces a typical chamber invocation for one of our services from 3 seconds to 0.65 seconds.

This change marginally increases the chance of something going wrong if the index file gets out-of-sync (eg. if a `chamber write` command dies part-way through). Previously, an out of sync index file could cause a secret not to appear when running list/export/exec, but if a secret was in the index file, then the lastest version was guarenteed to be used (since the latest secret value was fetched directly from its own S3 object every time). Now there's a new failure mode: if an old secret value is stored in the index file, then that value will be used by export/exec, even if the new value was successfully written to the secret's own S3 object before the `chamber write` command crashed. I don't think this is a problem worth worrying about, but it's worth flagging.