### PR TITLE
Add support for linux/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ linux: dist/chamber-$(VERSION)-linux-amd64
 dist/chamber-$(VERSION)-linux-amd64: | dist/
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath $(LDFLAGS) -o $@
 
+dist/chamber-$(VERSION)-linux-amd64: | dist/
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -trimpath $(LDFLAGS) -o $@
+
 dist/chamber-$(VERSION)-windows-amd64.exe: | dist/
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -trimpath $(LDFLAGS) -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ linux: dist/chamber-$(VERSION)-linux-amd64
 dist/chamber-$(VERSION)-linux-amd64: | dist/
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath $(LDFLAGS) -o $@
 
-dist/chamber-$(VERSION)-linux-amd64: | dist/
+dist/chamber-$(VERSION)-linux-arm64: | dist/
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -trimpath $(LDFLAGS) -o $@
 
 dist/chamber-$(VERSION)-windows-amd64.exe: | dist/

--- a/Makefile.release
+++ b/Makefile.release
@@ -67,6 +67,15 @@ publish-github-linux: dist/chamber-$(VERSION)-linux-amd64 | github-release
 	--name chamber-$(VERSION)-linux-amd64 \
 	--file $<
 
+publish-github-linux-arm64: dist/chamber-$(VERSION)-linux-arm64 | github-release
+	github-release upload \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo chamber \
+	--tag $(VERSION) \
+	--name chamber-$(VERSION)-linux-arm64 \
+	--file $<
+
 publish-github-windows: dist/chamber-$(VERSION)-windows-amd64.exe | github-release
 	github-release upload \
 	--security-token $$GH_LOGIN \


### PR DESCRIPTION
I need to run chamber on some AWS Graviton instances so adding the support to release a arm64 binary.