### PR TITLE
Added comment to our .circle file explaining where the GH_LOGIN env variable secret is stored

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,8 +131,9 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-[a-zA-Z0-9-]+)?/
       - publish-github:
-          # we don't need a context for this one; we've got a specific PAT in
-          # our GH_LOGIN env var
+          # GH_LOGIN env var for this project in circle contains the PAT (personal access token) IT manages for our service account
+          # IT has the secret stored in 1-password and it was also securely emailed
+          # to @aerlich and @jadametz originally
           requires:
             - dist
           filters:


### PR DESCRIPTION
Replaced the personal token from my account with the service account given by IT. "Documenting" it by adding this comment to the .circle file. Feel free to suggest I add it elsewhere. 

https://segment.atlassian.net/browse/TOOL-2071