### PR TITLE
improve `list-services` performance by increasing page size

### DIFF
--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -265,6 +265,7 @@ func (s *SSMStore) ListServices(service string, includeSecretName bool) ([]strin
 
 	if s.usePaths {
 		describeParametersInput = &ssm.DescribeParametersInput{
+			MaxResults: aws.Int64(50),
 			ParameterFilters: []*ssm.ParameterStringFilter{
 				{
 					Key:    aws.String("Name"),
@@ -275,6 +276,7 @@ func (s *SSMStore) ListServices(service string, includeSecretName bool) ([]strin
 		}
 	} else {
 		describeParametersInput = &ssm.DescribeParametersInput{
+			MaxResults: aws.Int64(50),
 			Filters: []*ssm.ParametersFilter{
 				{
 					Key:    aws.String("Name"),


### PR DESCRIPTION
Before this change I measured list-services taking 4m8.79s on stage, afterwards it took 1m18.70s. I don't think these numbers are super accurate because of Parameter Store's low rate limits and retries, but I think this will improve `list-services` performance.