### PR TITLE
Cleanup from merges/reverts of arm64 targets

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -30,7 +30,7 @@ PACKAGECLOUD_RPM_DISTROS := \
 
 publish: publish-github publish-packagecloud
 
-publish-github: publish-github-darwin publish-github-darwin-arm64 publish-github-linux publish-github-linux-arm64 publish-github-windows publish-github-deb publish-github-arm64-deb publish-github-rpm publish-github-sha256sums
+publish-github: publish-github-darwin publish-github-darwin-arm64 publish-github-linux publish-github-linux-arm64 publish-github-windows publish-github-deb publish-github-rpm publish-github-sha256sums
 
 publish-packagecloud: publish-packagecloud-deb publish-packagecloud-rpm
 
@@ -169,6 +169,7 @@ dist/chamber_$(VERSION)_amd64.rpm: dist/nfpm-$(VERSION).yaml dist/chamber-$(VERS
 .PHONY: \
 	publish-github \
 	publish-github-linux \
+	publish-github-linux-arm64 \
 	publish-github-windows \
 	publish-github-rpm \
 	publish-github-deb \


### PR DESCRIPTION
There was a publish-github-arm64-deb target under publish-github which no longer exists, and publish-github-linux-arm64 exists but isn't in PHONY. Cleaning that up, as I'd love to have a linux/arm64 package of chamber if there's a release sometime soon for use on graviton instances!