### PR TITLE
fix x509: certificate signed by unknown authority error when using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ COPY . .
 ARG VERSION
 RUN test -n "${VERSION}"
 
-RUN apk add -U make
+RUN apk add -U make ca-certificates
 RUN make linux VERSION=${VERSION}
-RUN apk --no-cache add ca-certificates
 
 FROM scratch AS run
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,11 @@ RUN test -n "${VERSION}"
 
 RUN apk add -U make
 RUN make linux VERSION=${VERSION}
+RUN apk --no-cache add ca-certificates
 
 FROM scratch AS run
 
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /go/src/github.com/segmentio/chamber/chamber /chamber
 
 ENTRYPOINT ["/chamber"]


### PR DESCRIPTION
This fixes the below error when using chamber in docker: `docker run segment/chamber:2.10.8 list-services ...`

```
Error: Failed to list store contents: RequestError: send request failed
caused by: Post "https://ssm.us-east-1.amazonaws.com/": x509: certificate signed by unknown authority
```