### PR TITLE
Automate release process using a github action module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,3 +115,4 @@ jobs:
         draft: true
         generate_release_notes: true
         files: dist/chamber*
+        tag_name: v2.10.10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,3 +91,27 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_PASSWD }}
+
+  test-github-release:
+    runs-on: ubuntu-latest
+    needs: dist
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: 'dist/*'
+
+      - name: Generate Changelog
+        run: scripts/changelog > ${{ github.workspace }}-CHANGELOG.txt
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          body_path: ${{ github.workspace }}-CHANGELOG.txt
+        with:
+          files: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,23 +95,24 @@ jobs:
   test-github-release:
     runs-on: ubuntu-latest
     needs: dist
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v3
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: actions/download-artifact@v3
       with:
         name: dist
         path: 'dist/*'
 
-      - name: Generate Changelog
-        run: scripts/changelog > ${{ github.workspace }}-CHANGELOG.txt
+    - name: Generate Changelog
+      run: scripts/changelog > ${{ github.workspace }}-CHANGELOG.txt
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
-          body_path: ${{ github.workspace }}-CHANGELOG.txt
-        with:
-          files: dist/*
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        draft: true
+        body_path: ${{ github.workspace }}-CHANGELOG.txt
+      with:
+        files: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,5 +114,4 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         draft: true
         body_path: ${{ github.workspace }}-CHANGELOG.txt
-      with:
         files: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,5 +114,4 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         draft: true
         generate_release_notes: true
-        body_path: ${{ github.workspace }}-CHANGELOG.txt
-        files: dist/*
+        files: dist/chamber*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: dist
-        path: 'dist/*'
+        path: 'dist'
 
     - name: Check dist
       run: ls -lrth dist/
@@ -116,5 +116,5 @@ jobs:
         generate_release_notes: true
         fail_on_unmatched_files: true
         files: |
-          ./dist/*
+          dist/*
         tag_name: v2.10.10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,8 @@ jobs:
         name: dist
         path: 'dist/*'
 
-    # - name: Generate Changelog
-    #   run: scripts/changelog > ${{ github.workspace }}-CHANGELOG.txt
+    - name: Check dist
+      run: ls -lrth dist/
 
     - name: Release
       uses: softprops/action-gh-release@v1
@@ -114,5 +114,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         draft: true
         generate_release_notes: true
-        files: dist/chamber*
+        fail_on_unmatched_files: true
+        files: |
+          ./dist/*
         tag_name: v2.10.10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,13 +105,14 @@ jobs:
         name: dist
         path: 'dist/*'
 
-    - name: Generate Changelog
-      run: scripts/changelog > ${{ github.workspace }}-CHANGELOG.txt
+    # - name: Generate Changelog
+    #   run: scripts/changelog > ${{ github.workspace }}-CHANGELOG.txt
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         draft: true
+        generate_release_notes: true
         body_path: ${{ github.workspace }}-CHANGELOG.txt
         files: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,30 +91,3 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_PASSWD }}
-
-  test-github-release:
-    runs-on: ubuntu-latest
-    needs: dist
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - uses: actions/download-artifact@v3
-      with:
-        name: dist
-        path: 'dist'
-
-    - name: Check dist
-      run: ls -lrth dist/
-
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        draft: true
-        generate_release_notes: true
-        fail_on_unmatched_files: true
-        files: |
-          dist/*
-        tag_name: v2.10.10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,31 +30,27 @@ jobs:
         name: dist
         path: 'dist/*'
  
-  publish-github:
-    strategy:
-      matrix:
-        go: ['1.16.x']
+  publish-github-release:
     runs-on: ubuntu-latest
     needs: dist
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
 
     - uses: actions/download-artifact@v3
       with:
         name: dist
-        path: 'dist/*'
+        path: 'dist'
 
-    - name: Setup Go 
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-    
-    - name: Install tools
-      run: make -f Makefile.tools github-release
-    
     - name: Release
-      run: make -f Makefile.release publish-github
+      uses: softprops/action-gh-release@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        generate_release_notes: true
+        fail_on_unmatched_files: true
+        files: |
+          dist/*
 
   publish-dockerhub:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
  
   publish-github-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: dist
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,7 @@ jobs:
     needs: dist
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
     - uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
The [PR merge](https://github.com/segmentio/chamber/pull/335) we made created an error when publishing to github. We decided to move away from the `github-release` step in the Makefile and use Github actions steps instead to publish to github. Since this is automated and more streamlined that what the Makefile is doing. Through this, we also decided to use the automated CHANGELOG generation provided by Github Actions.

Here is the error for the PR that was merged: https://github.com/segmentio/chamber/actions/runs/2116343973