### PR TITLE
Docker ARM64 builds with Docker Buildx

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -11,17 +11,15 @@ ifneq (,$(findstring -,$(VERSION)))
 endif
 
 publish-dockerhub:
-	docker build \
+	docker buildx build \
 		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR_PATCH) \
 		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR) \
 		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR) \
 		-t segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_NO_V) \
 		--build-arg VERSION=$(VERSION) \
+                --platform linux/amd64,linux/arm64 \
+                --push \
 		.
-	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR_PATCH)
-	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR_MINOR)
-	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_MAJOR)
-	docker push segment/chamber:$(DOCKERHUB_TAG_PREFIX)$(VERSION_NO_V)
 
 dist: dist/chamber-$(VERSION)-darwin-amd64 dist/chamber-$(VERSION)-darwin-arm64 dist/chamber-$(VERSION)-linux-amd64 dist/chamber-$(VERSION)-linux-arm64 dist/chamber-$(VERSION)-windows-amd64.exe dist/chamber_$(VERSION)_amd64.deb dist/chamber_$(VERSION)_amd64.rpm dist/chamber-$(VERSION).sha256sums
 


### PR DESCRIPTION
I ran into this [same issue](https://github.com/segmentio/chamber/issues/342), as your Docker release is only packaged for `linux/amd64`. It looks like your github actions are already setup to use docker buildx with multi-platform builds, so this PR just updates your docker build to package for `linux/arm64` as well. I can't test your github actions too easily, but hopefully this quick change just works; I verified it locally, but buildx sometimes needs a bit more setup.