### PR TITLE
fix: enhance error message to clarify validity of forward slashes in service names

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,7 +110,7 @@ func validateService(service string) error {
 		}
 	} else {
 		if !validServicePathFormat.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, forwardslashes, fullstops and underscores are allowed for service names", service)
+			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, forwardslashes, fullstops and underscores are allowed for service names. Service names must not start or end with a forwardslash", service)
 		}
 	}
 
@@ -125,7 +125,7 @@ func validateServiceWithLabel(service string) error {
 		}
 	} else {
 		if !validServicePathFormatWithLabel.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, forwardslashes, fullstops and underscores are allowed for service names, and colon followed by a label name", service)
+			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, forwardslashes, fullstops and underscores are allowed for service names, and colon followed by a label name. Service names must not start or end with a forwardslash or colon", service)
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,11 +106,11 @@ func validateService(service string) error {
 	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
 	if noPaths {
 		if !validServiceFormat.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, fullstops and underscores are allowed for service names", service)
+			return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, full stops and underscores are allowed for service names", service)
 		}
 	} else {
 		if !validServicePathFormat.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, forwardslashes, fullstops and underscores are allowed for service names. Service names must not start or end with a forwardslash", service)
+			return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, forward slashes, full stops and underscores are allowed for service names. Service names must not start or end with a forward slash", service)
 		}
 	}
 
@@ -121,11 +121,11 @@ func validateServiceWithLabel(service string) error {
 	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
 	if noPaths {
 		if !validServiceFormatWithLabel.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, fullstops and underscores are allowed for service names, and colon followed by a label name", service)
+			return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, full stops and underscores are allowed for service names, and colon followed by a label name", service)
 		}
 	} else {
 		if !validServicePathFormatWithLabel.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, forwardslashes, fullstops and underscores are allowed for service names, and colon followed by a label name. Service names must not start or end with a forwardslash or colon", service)
+			return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, forward slashes, full stops and underscores are allowed for service names, and colon followed by a label name. Service names must not start or end with a forward slash or colon", service)
 		}
 	}
 
@@ -134,7 +134,7 @@ func validateServiceWithLabel(service string) error {
 
 func validateKey(key string) error {
 	if !validKeyFormat.MatchString(key) {
-		return fmt.Errorf("Failed to validate key name '%s'.  Only alphanumeric, dashes, fullstops and underscores are allowed for key names", key)
+		return fmt.Errorf("Failed to validate key name '%s'. Only alphanumeric, dashes, full stops and underscores are allowed for key names", key)
 	}
 	return nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -130,6 +130,7 @@ func TestValidations(t *testing.T) {
 	invalidServicePathFormatWithLabel := []string{
 		"foo:current$",
 		"foo.:",
+		":foo/bar:current",
 		"foo.bar:cur|rent",
 	}
 


### PR DESCRIPTION
enhance error message to clarify validity of forward slashes in service names

Resolves #333 