### PR TITLE
Remove test-dockerhub-login step from feature branches pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,16 +78,3 @@ jobs:
       with:
         name: dist
         path: 'dist/*'
-
-  test-dockerhub-login:
-    runs-on: ubuntu-latest
-    needs: dist
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Login to DockerHub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Description

Removes `test-dockerhub-login` from feature branch pipeline because secrets aren't accessible from forked repositories. It should only only be executed during release(once PR is merged) pipeline when publishing to Docker Registry.