### PR TITLE
Update release Go version to 1.18.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   dist:
     strategy:
       matrix:
-        go: ['1.16.x']
+        go: ['1.18.x']
     runs-on: ubuntu-latest
 
     steps:
@@ -56,7 +56,7 @@ jobs:
   publish-dockerhub:
     strategy:
       matrix:
-        go: ['1.16.x']
+        go: ['1.18.x']
     runs-on: ubuntu-latest
     needs: dist
 


### PR DESCRIPTION
Going to release a new version of chamber now that it installs successfully with golang 1.18. For this, the [PR ](https://github.com/segmentio/chamber/pull/350)forgot to update the Go version in the release file.

[Jira ticket](https://segment.atlassian.net/browse/DEVEX-249)