### PR TITLE
feat: update go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   install-go-modules:
     strategy:
       matrix:
-        go: ['1.18.x', '1.17.x', '1.16.x', '1.15.x']
+        go: ['1.19.x']
     
     runs-on: ubuntu-latest
 
@@ -29,7 +29,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ['1.18.x', '1.17.x', '1.16.x']
+        go: ['1.19.x']
     runs-on: ubuntu-latest
 
     steps:
@@ -45,7 +45,6 @@ jobs:
     
     - name: Check modules are tidy and checked in
       run: |
-        export GO111MODULE=on
         go mod tidy
         if [ "$(git status --porcelain)" != "" ]; then
           echo "git tree is dirty after tidying modules"
@@ -57,7 +56,7 @@ jobs:
   dist:
     strategy:
       matrix:
-        go: ['1.18.x', '1.17.x', '1.16.x']
+        go: ['1.19.x']
     runs-on: ubuntu-latest
     needs: test
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   dist:
     strategy:
       matrix:
-        go: ['1.16.x']
+        go: ['1.19.x']
     runs-on: ubuntu-latest
 
     steps:
@@ -56,7 +56,7 @@ jobs:
   publish-dockerhub:
     strategy:
       matrix:
-        go: ['1.16.x']
+        go: ['1.19.x']
     runs-on: ubuntu-latest
     needs: dist
 

--- a/go.mod
+++ b/go.mod
@@ -2,20 +2,25 @@ module github.com/segmentio/chamber/v2
 
 require (
 	github.com/aws/aws-sdk-go v1.38.22
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/magiconair/properties v1.8.0
 	github.com/pkg/errors v0.9.1
-	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c // indirect
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.2 // indirect
 	github.com/stretchr/testify v1.2.2
-	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098
 	gopkg.in/segmentio/analytics-go.v3 v3.0.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-go 1.13
+require (
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c // indirect
+	github.com/spf13/pflag v1.0.2 // indirect
+	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
+)
+
+go 1.19


### PR DESCRIPTION
Resolves https://github.com/segmentio/chamber/issues/363

Updates go version from 1.13 to 1.19.