### PR TITLE
fix: update golang version to 1.19 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine AS build
+FROM golang:1.19-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .


### PR DESCRIPTION
We recently got pinged about a security vulnerability: https://github.com/segmentio/chamber/issues/367

This PR aims to fix that by updating the golang version in the Dockerfile to `1.19`