### PR TITLE
chore: Update go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,20 +2,25 @@ module github.com/segmentio/chamber/v2
 
 require (
 	github.com/aws/aws-sdk-go v1.38.22
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/magiconair/properties v1.8.0
 	github.com/pkg/errors v0.9.1
-	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c // indirect
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.2 // indirect
 	github.com/stretchr/testify v1.2.2
-	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098
 	gopkg.in/segmentio/analytics-go.v3 v3.0.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-go 1.13
+require (
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c // indirect
+	github.com/spf13/pflag v1.0.2 // indirect
+	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
+)
+
+go 1.19


### PR DESCRIPTION
This will match go 1.19.x that is used in the Dockerfile already

Notes:

- Why are there two require sections now?
  - Because in Go 1.17 the module graph has been changed to enable pruning and lazy loading. The second require block contains indirect dependencies
- CI
  - Lowest chamber builds for is 1.15 [here](https://github.com/segmentio/chamber/blob/301d5feb8dccca57c524ca2fda418f8aa96fcc9d/.github/workflows/build.yml#L14)