### PR TITLE
chore(deps): resolve aws sso profile issues by updating aws-sdk-go@v1.38

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/segmentio/chamber/v2
 
 require (
-	github.com/aws/aws-sdk-go v1.38.22
+	github.com/aws/aws-sdk-go v1.38.71
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.38.22 h1:hJwaMazDt7EP4Rz/T4RQmdchWWv+YB3+/i6AOUWjVL0=
-github.com/aws/aws-sdk-go v1.38.22/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.71 h1:aWhtgoOiDhBCfaAj9XbxzcyvjEAKovbtv7d5mCVBZXw=
+github.com/aws/aws-sdk-go v1.38.71/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## what
- [x] Use latest github.com/aws/aws-sdk-go@v1.38

## why
- Resolve `AWS_PROFILE` with `aws sso` issues

## references
- Closes https://github.com/segmentio/chamber/issues/376

## commands

Before update
```bash
✗ AWS_PROFILE=test chamber list-services
Error: Failed to get secret store: SharedConfigErr: only one credential type may be specified per profile: source profile, credential source, credential process, web identity token, or sso
```

```bash
✗ go get -u github.com/aws/aws-sdk-go@v1.38
```

~Replace was necessary in order to run `go get -u`~
```bash
✗ go mod edit -replace gopkg.in/segmentio/analytics-go.v3=github.com/segmentio/analytics-go/v3@v3.2.1
✗ go mod tidy
```

After update
```bash
✗ rm -f chamber && make build
✗ AWS_PROFILE=test ./chamber list-services
Service
hello-world/secret
```
