### PR TITLE
feat: bump minimum go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
   install-go-modules:
     strategy:
       matrix:
-        go: ['1.19.x', '1.18.x', '1.17.x', '1.16.x', '1.15.x']
-    
+        go: ['1.20.x', '1.19.x', '1.18.x', '1.17.x', '1.16.x']
+
     runs-on: ubuntu-latest
 
     steps:
@@ -23,26 +23,26 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Test install Go modules for v${{ matrix.go }} 
+    - name: Test install Go modules for v${{ matrix.go }}
       run: go install -v . && chamber version
 
   test:
     strategy:
       matrix:
-        go: ['1.19.x', '1.18.x', '1.17.x', '1.16.x']
+        go: ['1.20.x', '1.19.x', '1.18.x', '1.17.x', '1.16.x']
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Go 
+    - name: Setup Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
-    
+
     - name: Test
       run: make test
-    
+
     - name: Check modules are tidy and checked in
       run: |
         export GO111MODULE=on
@@ -57,21 +57,21 @@ jobs:
   dist:
     strategy:
       matrix:
-        go: ['1.19.x', '1.18.x', '1.17.x', '1.16.x']
+        go: ['1.20.x', '1.19.x', '1.18.x', '1.17.x', '1.16.x']
     runs-on: ubuntu-latest
     needs: test
-    
+
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Go 
+    - name: Setup Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
-    
+
     - name: Install nfpm, rpmbuild
       run: sudo make -f Makefile.tools nfpm-debian rpmbuild-debian
-    
+
     - name: Make distributables
       run: make -f Makefile.release dist
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    tags: 
+    tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]-[a-zA-Z0-9]+'
 
@@ -15,21 +15,21 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Go 
+    - name: Setup Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
-    
+
     - name: Install nfpm, rpmbuild
       run: sudo make -f Makefile.tools nfpm-debian rpmbuild-debian
-    
+
     - name: Make distributables
       run: make -f Makefile.release dist
     - uses: actions/upload-artifact@v3
       with:
         name: dist
         path: 'dist/*'
- 
+
   publish-github-release:
     runs-on: ubuntu-latest
     permissions:
@@ -68,7 +68,7 @@ jobs:
         name: dist
         path: 'dist/*'
 
-    - name: Setup Go 
+    - name: Setup Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
@@ -84,7 +84,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
+
     - name: Release
-      run: 
+      run:
         make -f Makefile.release publish-dockerhub

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
### Description

Bumps the minimum go version for `chamber` to be go 1.16. This aligns with our current test and distributables support.
