### PR TITLE
Fix accumulated papercuts

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
+	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/store"
 	"github.com/segmentio/chamber/v2/utils"
 	"github.com/spf13/cobra"
-	analytics "github.com/segmentio/analytics-go/v3"
 )
 
 // deleteCmd represents the delete command
@@ -26,7 +27,7 @@ func init() {
 func delete(cmd *cobra.Command, args []string) error {
 	service := utils.NormalizeService(args[0])
 	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
+		return fmt.Errorf("Failed to validate service: %w", err)
 	}
 
 	key := args[1]
@@ -35,7 +36,7 @@ func delete(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := validateKey(key); err != nil {
-		return errors.Wrap(err, "Failed to validate key")
+		return fmt.Errorf("Failed to validate key: %w", err)
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
@@ -52,7 +53,7 @@ func delete(cmd *cobra.Command, args []string) error {
 	}
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 	secretId := store.SecretId{
 		Service: service,

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -5,10 +5,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/utils"
 	"github.com/spf13/cobra"
-	analytics "github.com/segmentio/analytics-go/v3"
 )
 
 var (
@@ -30,16 +29,16 @@ func init() {
 func env(cmd *cobra.Command, args []string) error {
 	service := utils.NormalizeService(args[0])
 	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
+		return fmt.Errorf("Failed to validate service: %w", err)
 	}
 
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 	rawSecrets, err := secretStore.ListRaw(service)
 	if err != nil {
-		return errors.Wrap(err, "Failed to list store contents")
+		return fmt.Errorf("Failed to list store contents: %w", err)
 	}
 
 	if analyticsEnabled && analyticsClient != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/environ"
 	"github.com/spf13/cobra"
-	analytics "github.com/segmentio/analytics-go/v3"
 )
 
 // When true, only use variables retrieved from the backend, do not inherit existing environment variables
@@ -33,10 +33,10 @@ var execCmd = &cobra.Command{
 			return errors.New("please separate services and command with '--'. See usage")
 		}
 		if err := cobra.MinimumNArgs(1)(cmd, args[:dashIx]); err != nil {
-			return errors.Wrap(err, "at least one service must be specified")
+			return fmt.Errorf("at least one service must be specified: %w", err)
 		}
 		if err := cobra.MinimumNArgs(1)(cmd, args[dashIx:]); err != nil {
-			return errors.Wrap(err, "must specify command to run. See usage")
+			return fmt.Errorf("must specify command to run. See usage: %w", err)
 		}
 		return nil
 	},
@@ -88,13 +88,13 @@ func execRun(cmd *cobra.Command, args []string) error {
 
 	for _, service := range services {
 		if err := validateServiceWithLabel(service); err != nil {
-			return errors.Wrap(err, "Failed to validate service")
+			return fmt.Errorf("Failed to validate service: %w", err)
 		}
 	}
 
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
 
@@ -131,7 +131,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 				err = env.Load(secretStore, service, &collisions)
 			}
 			if err != nil {
-				return errors.Wrap(err, "Failed to list store contents")
+				return fmt.Errorf("Failed to list store contents: %w", err)
 			}
 
 			for _, c := range collisions {

--- a/cmd/exec_default.go
+++ b/cmd/exec_default.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin
+//go:build !linux && !darwin
 
 package cmd
 

--- a/cmd/exec_default.go
+++ b/cmd/exec_default.go
@@ -3,12 +3,11 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	osexec "os/exec"
 	"os/signal"
 	"syscall"
-
-	"github.com/pkg/errors"
 )
 
 // exec executes the given command, passing it args and setting its environment
@@ -25,7 +24,7 @@ func exec(command string, args []string, env []string) error {
 	signal.Notify(sigChan)
 
 	if err := ecmd.Start(); err != nil {
-		return errors.Wrap(err, "Failed to start command")
+		return fmt.Errorf("Failed to start command: %w", err)
 	}
 
 	go func() {
@@ -37,7 +36,7 @@ func exec(command string, args []string, env []string) error {
 
 	if err := ecmd.Wait(); err != nil {
 		ecmd.Process.Signal(os.Kill)
-		return errors.Wrap(err, "Failed to wait for command termination")
+		return fmt.Errorf("Failed to wait for command termination: %w", err)
 	}
 
 	waitStatus := ecmd.ProcessState.Sys().(syscall.WaitStatus)

--- a/cmd/exec_unix.go
+++ b/cmd/exec_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+//go:build linux || darwin
 
 package cmd
 

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/v2/store"
 	"github.com/spf13/cobra"
 )
@@ -42,11 +41,11 @@ func find(cmd *cobra.Command, args []string) error {
 
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 	services, err := secretStore.ListServices(blankService, includeSecrets)
 	if err != nil {
-		return errors.Wrap(err, "Failed to list store contents")
+		return fmt.Errorf("Failed to list store contents: %w", err)
 	}
 
 	if byValue {

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -15,21 +15,9 @@ func TestFindFunctions(t *testing.T) {
 		params string
 		output string
 	}{
-		{
-			"service1",
-			"/service1/key_one",
-			"service1",
-		},
-		{
-			"service2",
-			"/service2/subService/key_two",
-			"service2/subService",
-		},
-		{
-			"service3",
-			"/service3/subService/subSubService/key_three",
-			"service3/subService/subSubService",
-		},
+		{name: "service1", params: "/service1/key_one", output: "service1"},
+		{name: "service2", params: "/service2/subService/key_two", output: "service2/subService"},
+		{name: "service3", params: "/service3/subService/subSubService/key_three", output: "service3/subService/subSubService"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -45,52 +33,40 @@ func TestFindFunctions(t *testing.T) {
 		output     []store.SecretId
 	}{
 		{
-			"findNoMatches",
-			[]string{"/service1/launch_darkly_key",
+			name: "findNoMatches",
+			services: []string{
+				"/service1/launch_darkly_key",
 				"/service2/s3_bucket_base",
 				"/service3/slack_token",
 			},
-			"s3_bucket",
-			[]store.SecretId{},
+			searchTerm: "s3_bucket",
+			output:     []store.SecretId{},
 		},
 		{
-			"findSomeMatches",
-			[]string{"/service1/s3_bucket",
+			name: "findSomeMatches",
+			services: []string{
+				"/service1/s3_bucket",
 				"/service2/s3_bucket_base",
 				"/service3/s3_bucket",
 			},
-			"s3_bucket",
-			[]store.SecretId{
-				{
-					"service1",
-					"s3_bucket",
-				},
-				{
-					"service3",
-					"s3_bucket",
-				},
+			searchTerm: "s3_bucket",
+			output: []store.SecretId{
+				{Service: "service1", Key: "s3_bucket"},
+				{Service: "service3", Key: "s3_bucket"},
 			},
 		},
 		{
-			"findEverythingMatches",
-			[]string{"/service1/s3_bucket",
+			name: "findEverythingMatches",
+			services: []string{
+				"/service1/s3_bucket",
 				"/service2/s3_bucket",
 				"/service3/s3_bucket",
 			},
-			"s3_bucket",
-			[]store.SecretId{
-				{
-					"service1",
-					"s3_bucket",
-				},
-				{
-					"service2",
-					"s3_bucket",
-				},
-				{
-					"service3",
-					"s3_bucket",
-				},
+			searchTerm: "s3_bucket",
+			output: []store.SecretId{
+				{Service: "service1", Key: "s3_bucket"},
+				{Service: "service2", Key: "s3_bucket"},
+				{Service: "service3", Key: "s3_bucket"},
 			},
 		},
 	}
@@ -115,126 +91,126 @@ func TestFindFunctions(t *testing.T) {
 		output     []store.SecretId
 	}{
 		{
-			"findNoMatches",
-			[]store.Secret{
-				store.Secret{
-					&valueDarklyToken,
-					store.SecretMetadata{
-						time.Now(),
-						"no one",
-						0,
-						"/service1/launch_darkly_key",
+			name: "findNoMatches",
+			secrets: []store.Secret{
+				{
+					Value: &valueDarklyToken,
+					Meta: store.SecretMetadata{
+						Created:   time.Now(),
+						CreatedBy: "no one",
+						Version:   0,
+						Key:       "/service1/launch_darkly_key",
 					},
 				},
-				store.Secret{
-					&valueSlackToken,
-					store.SecretMetadata{
-						time.Now(),
-						"no one",
-						0,
-						"/service1/slack_token",
+				{
+					Value: &valueSlackToken,
+					Meta: store.SecretMetadata{
+						Created:   time.Now(),
+						CreatedBy: "no one",
+						Version:   0,
+						Key:       "/service1/slack_token",
 					},
 				},
-				store.Secret{
-					&valueBadS3Bucket,
-					store.SecretMetadata{
-						time.Now(),
-						"no one",
-						0,
-						"/service1/s3_bucket",
+				{
+					Value: &valueBadS3Bucket,
+					Meta: store.SecretMetadata{
+						Created:   time.Now(),
+						CreatedBy: "no one",
+						Version:   0,
+						Key:       "/service1/s3_bucket",
 					},
 				},
 			},
-			"s3://this_bucket",
-			[]store.SecretId{},
+			searchTerm: "s3://this_bucket",
+			output:     []store.SecretId{},
 		},
 		{
 			"findSomeMatches",
 			[]store.Secret{
-				store.Secret{
-					&valueDarklyToken,
-					store.SecretMetadata{
-						time.Now(),
-						"no one",
-						0,
-						"/service1/launch_darkly_key",
+				{
+					Value: &valueDarklyToken,
+					Meta: store.SecretMetadata{
+						Created:   time.Now(),
+						CreatedBy: "no one",
+						Version:   0,
+						Key:       "/service1/launch_darkly_key",
 					},
 				},
-				store.Secret{
-					&valueGoodS3Bucket,
-					store.SecretMetadata{
-						time.Now(),
-						"no one",
-						0,
-						"/service1/s3_bucket_name",
+				{
+					Value: &valueGoodS3Bucket,
+					Meta: store.SecretMetadata{
+						Created:   time.Now(),
+						CreatedBy: "no one",
+						Version:   0,
+						Key:       "/service1/s3_bucket_name",
 					},
 				},
-				store.Secret{
-					&valueGoodS3Bucket,
-					store.SecretMetadata{
-						time.Now(),
-						"no one",
-						0,
-						"/service1/s3_bucket",
+				{
+					Value: &valueGoodS3Bucket,
+					Meta: store.SecretMetadata{
+						Created:   time.Now(),
+						CreatedBy: "no one",
+						Version:   0,
+						Key:       "/service1/s3_bucket",
 					},
 				},
 			},
 			"s3://this_bucket",
 			[]store.SecretId{
 				{
-					"service1",
-					"s3_bucket_name",
+					Service: "service1",
+					Key:     "s3_bucket_name",
 				},
 				{
-					"service1",
-					"s3_bucket",
+					Service: "service1",
+					Key:     "s3_bucket",
 				},
 			},
 		},
 		{
 			"findEverythingMatches",
 			[]store.Secret{
-				store.Secret{
-					&valueGoodS3Bucket,
-					store.SecretMetadata{
-						time.Now(),
-						"no one",
-						0,
-						"/service1/s3_bucket_base",
+				{
+					Value: &valueGoodS3Bucket,
+					Meta: store.SecretMetadata{
+						Created:   time.Now(),
+						CreatedBy: "no one",
+						Version:   0,
+						Key:       "/service1/s3_bucket_base",
 					},
 				},
-				store.Secret{
-					&valueGoodS3Bucket,
-					store.SecretMetadata{
-						time.Now(),
-						"no one",
-						0,
-						"/service1/s3_bucket_name",
+				{
+					Value: &valueGoodS3Bucket,
+					Meta: store.SecretMetadata{
+						Created:   time.Now(),
+						CreatedBy: "no one",
+						Version:   0,
+						Key:       "/service1/s3_bucket_name",
 					},
 				},
-				store.Secret{
-					&valueGoodS3Bucket,
-					store.SecretMetadata{
-						time.Now(),
-						"no one",
-						0,
-						"/service1/s3_bucket",
+				{
+					Value: &valueGoodS3Bucket,
+					Meta: store.SecretMetadata{
+						Created:   time.Now(),
+						CreatedBy: "no one",
+						Version:   0,
+						Key:       "/service1/s3_bucket",
 					},
 				},
 			},
 			"s3://this_bucket",
 			[]store.SecretId{
 				{
-					"service1",
-					"s3_bucket_base",
+					Service: "service1",
+					Key:     "s3_bucket_base",
 				},
 				{
-					"service1",
-					"s3_bucket_name",
+					Service: "service1",
+					Key:     "s3_bucket_name",
 				},
 				{
-					"service1",
-					"s3_bucket",
+					Service: "service1",
+					Key:     "s3_bucket",
 				},
 			},
 		},

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -5,11 +5,10 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/store"
 	"github.com/segmentio/chamber/v2/utils"
 	"github.com/spf13/cobra"
-	analytics "github.com/segmentio/analytics-go/v3"
 )
 
 // historyCmd represents the history command
@@ -27,12 +26,12 @@ func init() {
 func history(cmd *cobra.Command, args []string) error {
 	service := utils.NormalizeService(args[0])
 	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
+		return fmt.Errorf("Failed to validate service: %w", err)
 	}
 
 	key := utils.NormalizeKey(args[1])
 	if err := validateKey(key); err != nil {
-		return errors.Wrap(err, "Failed to validate key")
+		return fmt.Errorf("Failed to validate key: %w", err)
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
@@ -50,7 +49,7 @@ func history(cmd *cobra.Command, args []string) error {
 
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 	secretId := store.SecretId{
 		Service: service,
@@ -59,7 +58,7 @@ func history(cmd *cobra.Command, args []string) error {
 
 	events, err := secretStore.History(secretId)
 	if err != nil {
-		return errors.Wrap(err, "Failed to get history")
+		return fmt.Errorf("Failed to get history: %w", err)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -5,11 +5,10 @@ import (
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/store"
 	"github.com/segmentio/chamber/v2/utils"
 	"github.com/spf13/cobra"
-	analytics "github.com/segmentio/analytics-go/v3"
 	"gopkg.in/yaml.v3"
 )
 
@@ -31,7 +30,7 @@ func init() {
 func importRun(cmd *cobra.Command, args []string) error {
 	service := utils.NormalizeService(args[0])
 	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
+		return fmt.Errorf("Failed to validate service: %w", err)
 	}
 
 	var in io.Reader
@@ -43,7 +42,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 	} else {
 		in, err = os.Open(file)
 		if err != nil {
-			return errors.Wrap(err, "Failed to open file")
+			return fmt.Errorf("Failed to open file: %w", err)
 		}
 	}
 
@@ -51,7 +50,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 
 	decoder := yaml.NewDecoder(in)
 	if err := decoder.Decode(&toBeImported); err != nil {
-		return errors.Wrap(err, "Failed to decode input as json")
+		return fmt.Errorf("Failed to decode input as json: %w", err)
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
@@ -68,7 +67,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 
 	for key, value := range toBeImported {
@@ -80,7 +79,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 			Key:     key,
 		}
 		if err := secretStore.Write(secretId, value); err != nil {
-			return errors.Wrap(err, "Failed to write secret")
+			return fmt.Errorf("Failed to write secret: %w", err)
 		}
 	}
 

--- a/cmd/list-services.go
+++ b/cmd/list-services.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/v2/utils"
 	"github.com/spf13/cobra"
 )
@@ -37,11 +36,11 @@ func listServices(cmd *cobra.Command, args []string) error {
 	}
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 	secrets, err := secretStore.ListServices(service, includeSecretName)
 	if err != nil {
-		return errors.Wrap(err, "Failed to list store contents")
+		return fmt.Errorf("Failed to list store contents: %w", err)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,11 +7,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/store"
 	"github.com/segmentio/chamber/v2/utils"
 	"github.com/spf13/cobra"
-	analytics "github.com/segmentio/analytics-go/v3"
 )
 
 // listCmd represents the list command
@@ -40,7 +39,7 @@ func init() {
 func list(cmd *cobra.Command, args []string) error {
 	service := utils.NormalizeService(args[0])
 	if err := validateServiceWithLabel(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
+		return fmt.Errorf("Failed to validate service: %w", err)
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
@@ -57,11 +56,11 @@ func list(cmd *cobra.Command, args []string) error {
 
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 	secrets, err := secretStore.List(service, withValues)
 	if err != nil {
-		return errors.Wrap(err, "Failed to list store contents")
+		return fmt.Errorf("Failed to list store contents: %w", err)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -5,11 +5,10 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/store"
 	"github.com/segmentio/chamber/v2/utils"
 	"github.com/spf13/cobra"
-	analytics "github.com/segmentio/analytics-go/v3"
 )
 
 var (
@@ -34,12 +33,12 @@ func init() {
 func read(cmd *cobra.Command, args []string) error {
 	service := utils.NormalizeService(args[0])
 	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
+		return fmt.Errorf("Failed to validate service: %w", err)
 	}
 
 	key := utils.NormalizeKey(args[1])
 	if err := validateKey(key); err != nil {
-		return errors.Wrap(err, "Failed to validate key")
+		return fmt.Errorf("Failed to validate key: %w", err)
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
@@ -57,7 +56,7 @@ func read(cmd *cobra.Command, args []string) error {
 
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 
 	secretId := store.SecretId{
@@ -67,7 +66,7 @@ func read(cmd *cobra.Command, args []string) error {
 
 	secret, err := secretStore.Read(secretId, version)
 	if err != nil {
-		return errors.Wrap(err, "Failed to read")
+		return fmt.Errorf("Failed to read: %w", err)
 	}
 
 	if quiet {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -8,10 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/store"
 	"github.com/spf13/cobra"
-	analytics "github.com/segmentio/analytics-go/v3"
 )
 
 // Regex's used to validate service and key names

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	analytics "github.com/segmentio/analytics-go/v3"
+	"github.com/spf13/cobra"
 )
 
 // versionCmd represents the version command

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -2,15 +2,15 @@ package cmd
 
 import (
 	"bufio"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
+	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/store"
 	"github.com/segmentio/chamber/v2/utils"
 	"github.com/spf13/cobra"
-	analytics "github.com/segmentio/analytics-go/v3"
 )
 
 var (
@@ -35,12 +35,12 @@ func init() {
 func write(cmd *cobra.Command, args []string) error {
 	service := utils.NormalizeService(args[0])
 	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
+		return fmt.Errorf("Failed to validate service: %w", err)
 	}
 
 	key := utils.NormalizeKey(args[1])
 	if err := validateKey(key); err != nil {
-		return errors.Wrap(err, "Failed to validate key")
+		return fmt.Errorf("Failed to validate key: %w", err)
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
@@ -77,7 +77,7 @@ func write(cmd *cobra.Command, args []string) error {
 
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return errors.Wrap(err, "Failed to get secret store")
+		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
 
 	secretId := store.SecretId{

--- a/environ/environ.go
+++ b/environ/environ.go
@@ -176,13 +176,13 @@ func (e *Environ) loadStrictOne(rawSecrets []store.RawSecret, valueExpected stri
 		envVarKeysAdded[envVarKey] = struct{}{}
 		e.Set(envVarKey, rawSecret.Value)
 	}
-	for k, _ := range parentExpects {
+	for k := range parentExpects {
 		return ErrStoreMissingKey{Key: k, ValueExpected: valueExpected}
 	}
 
 	if pristine {
 		// unset all envvars that were in the parent env but not in store
-		for k, _ := range parentMap {
+		for k := range parentMap {
 			if _, ok := envVarKeysAdded[k]; !ok {
 				e.Unset(k)
 			}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/aws/aws-sdk-go v1.44.257
 	github.com/magiconair/properties v1.8.7
-	github.com/pkg/errors v0.9.1
 	github.com/segmentio/analytics-go/v3 v3.2.1
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,6 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/segmentio/chamber/v2/cmd"
+import (
+	"github.com/segmentio/chamber/v2/cmd"
+)
 
 var (
 	// This is updated by linker flags during build

--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/pkg/errors"
 )
 
 // latest is used to keep a single object in s3 with all of the
@@ -188,7 +188,7 @@ func (s *S3KMSStore) List(service string, includeValues bool) ([]Secret, error) 
 	return secrets, nil
 }
 
-// ListRaw returns RawSecrets by extracting them from the index file. It only ever uses the 
+// ListRaw returns RawSecrets by extracting them from the index file. It only ever uses the
 // index file; it never consults the actual secrets, so if the index file is out of sync, these
 // results will reflect that.
 func (s *S3KMSStore) ListRaw(service string) ([]RawSecret, error) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
-import "strings"
+import (
+	"strings"
+)
 
 // NormalizeService normalizes a provided service to a common format
 func NormalizeService(service string) string {


### PR DESCRIPTION
![images (2)](https://github.com/segmentio/chamber/assets/344926/dc5d32e4-c36d-40ef-80b1-5a08e769f656)

So, `chamber` has accumulated a number of papercuts over the years: small things, easy to overlook but that sting in the moment. Nothing that's going to completely halt operation, but will annoy you (read: me, Joe Sportsbar Average User) when you touch them. Here's a swing at fixing a few of these up in the hopes of further improving future maintenance: 

- Improve test readability for `cmd/find_test.go`
- Use contemporary `go:build` directives format instead of deprecated `+build:`
- Remove legacy 3rd party error wrapping package and use contemporary stdlib error wrapping