### PR TITLE
Fix `chamber env` and `chamber export -f dotenv`

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -3,12 +3,18 @@ package cmd
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
+	"github.com/alessio/shellescape"
 	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v2/utils"
+
 	"github.com/spf13/cobra"
 )
+
+// originally ported from github.com/joho/godotenv
+const doubleQuoteSpecialChars = "\\\n\r\"!$`"
 
 var (
 	// envCmd represents the env command
@@ -18,27 +24,53 @@ var (
 		Args:  cobra.ExactArgs(1),
 		RunE:  env,
 	}
-	pattern *regexp.Regexp
+	preserveCase   bool
+	escapeSpecials bool
 )
 
 func init() {
+	envCmd.Flags().BoolVarP(&preserveCase, "preserve-case", "p", false, "preserve variable name case")
+	envCmd.Flags().BoolVarP(&escapeSpecials, "escape-strings", "e", false, "escape special characters in values")
 	RootCmd.AddCommand(envCmd)
-	pattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
 }
 
+// Print all secrets to standard out as valid shell key-value
+// pairs or return an error if secrets cannot be safely
+// represented as shell words.
 func env(cmd *cobra.Command, args []string) error {
+	envVars, err := exportEnv(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	for i := range envVars {
+		fmt.Println(envVars[i])
+	}
+
+	return nil
+}
+
+// Handle the actual work of retrieving and validating secrets.
+// Returns a []string, with each string being a `key=value` pair,
+// and returns any errors encountered along the way.
+// Keys will be converted into valid shell variable names,
+// and converted to uppercase unless --preserve is passed.
+// Key ordering is non-deterministic and unstable, as returned
+// value from a given secret store is non-deterministic and unstable.
+func exportEnv(cmd *cobra.Command, args []string) ([]string, error) {
 	service := utils.NormalizeService(args[0])
 	if err := validateService(service); err != nil {
-		return fmt.Errorf("Failed to validate service: %w", err)
+		return nil, fmt.Errorf("Failed to validate service: %w", err)
 	}
 
 	secretStore, err := getSecretStore()
 	if err != nil {
-		return fmt.Errorf("Failed to get secret store: %w", err)
+		return nil, fmt.Errorf("Failed to get secret store: %w", err)
 	}
+
 	rawSecrets, err := secretStore.ListRaw(service)
 	if err != nil {
-		return fmt.Errorf("Failed to list store contents: %w", err)
+		return nil, fmt.Errorf("Failed to list store contents: %w", err)
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
@@ -53,24 +85,113 @@ func env(cmd *cobra.Command, args []string) error {
 		})
 	}
 
+	params := make(map[string]string)
 	for _, rawSecret := range rawSecrets {
-		fmt.Printf("export %s=%s\n",
-			strings.ToUpper(key(rawSecret.Key)),
-			shellescape(rawSecret.Value))
+		params[key(rawSecret.Key)] = rawSecret.Value
+	}
+
+	out, err := buildEnvOutput(params)
+	if err != nil {
+		return nil, err
+	}
+
+	// ensure output prints variable declarations as exported
+	for i := range out {
+		// Sprintf because each declaration already ends in a newline
+		out[i] = fmt.Sprintf("export %s", out[i])
+	}
+
+	return out, nil
+}
+
+// output will be returned lexically sorted by key name
+func buildEnvOutput(params map[string]string) ([]string, error) {
+	out := []string{}
+	for _, key := range sortedKeys(params) {
+		name := sanitizeKey(key)
+		if !preserveCase {
+			name = strings.ToUpper(name)
+		}
+
+		if err := validateShellName(name); err != nil {
+			return nil, err
+		}
+
+		// the default format prints all escape sequences as
+		// string literals, and wraps values in single quotes
+		// if they're unsafe or multi-line strings.
+		s := fmt.Sprintf(`%s=%s`, name, shellescape.Quote(params[key]))
+		if escapeSpecials {
+			// this format collapses special characters like newlines
+			// or carriage returns. requires escape sequences to be interpolated
+			// by whatever parses our key="value" pairs.
+			s = fmt.Sprintf(`%s="%s"`, name, doubleQuoteEscape(params[key]))
+		}
+
+		// don't rely on printf to handle properly quoting or
+		// escaping shell output -- just white-knuckle it ourselves.
+
+		out = append(out, s)
+	}
+
+	return out, nil
+}
+
+// The name of a variable can contain only letters (a-z, case insensitive),
+// numbers (0-9) or the underscore character (_). It may only begin with
+// a letter or an underscore.
+func validateShellName(s string) error {
+	shellChars := regexp.MustCompile(`^[A-Za-z0-9_]+$`).MatchString
+	validShellName := regexp.MustCompile(`^[A-Za-z_]{1}`).MatchString
+
+	if !shellChars(s) {
+		return fmt.Errorf("cmd: %q contains invalid characters for a shell variable name", s)
+	}
+
+	if !validShellName(s) {
+		return fmt.Errorf("cmd: shell variable name %q must start with a letter or underscore", s)
 	}
 
 	return nil
 }
 
-// shellescape returns a shell-escaped version of the string s. The returned value
-// is a string that can safely be used as one token in a shell command line.
-func shellescape(s string) string {
-	if len(s) == 0 {
-		return "''"
-	}
-	if pattern.MatchString(s) {
-		return "'" + strings.Replace(s, "'", "'\"'\"'", -1) + "'"
-	}
+// note that all character width will be preserved; a single space
+// (or period, tab, or newline) will be replaced with a single underscore.
+// no squeezing/collapsing of replaced characters is performed at all.
+func sanitizeKey(s string) string {
+	// I promise, we don't actually care about allocations here.
+	// allocate *away*.
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, ".", "_")
+	// whitespace gets a visit from The Big Hammer that is regex.
+	s = regexp.MustCompile(`[[:space:]]`).ReplaceAllString(s, "_")
 
 	return s
+}
+
+// originally ported from github.com/joho/godotenv
+func doubleQuoteEscape(line string) string {
+	for _, c := range doubleQuoteSpecialChars {
+		toReplace := "\\" + string(c)
+		if c == '\n' {
+			toReplace = `\n`
+		}
+		if c == '\r' {
+			toReplace = `\r`
+		}
+		line = strings.Replace(line, string(c), toReplace, -1)
+	}
+	return line
+}
+
+func sortedKeys(params map[string]string) []string {
+	keys := make([]string, len(params))
+	i := 0
+	for k := range params {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -192,7 +192,7 @@ func doubleQuoteEscape(line string) string {
 // []string{"A", "Dog", "b", "cat", "dog"}. That doesn't
 // really matter here but it may lead to surprises.
 func sortedKeys(params map[string]string) []string {
-	keys := make([]string, len(params))
+	keys := []string{}
 
 	for key := range params {
 		keys = append(keys, key)

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -186,12 +186,16 @@ func doubleQuoteEscape(line string) string {
 	return line
 }
 
+// return the keys from params, sorted by keyname.
+// note that sort.Strings() is not case insensitive.
+// e.g. []string{"A", "b", "cat", "Dog", "dog"} will sort as:
+// []string{"A", "Dog", "b", "cat", "dog"}. That doesn't
+// really matter here but it may lead to surprises.
 func sortedKeys(params map[string]string) []string {
 	keys := make([]string, len(params))
-	i := 0
-	for k := range params {
-		keys[i] = k
-		i++
+
+	for key := range params {
+		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	return keys

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -29,6 +29,7 @@ var (
 )
 
 func init() {
+	envCmd.Flags().SortFlags = false
 	envCmd.Flags().BoolVarP(&preserveCase, "preserve-case", "p", false, "preserve variable name case")
 	envCmd.Flags().BoolVarP(&escapeSpecials, "escape-strings", "e", false, "escape special characters in values")
 	RootCmd.AddCommand(envCmd)

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -46,7 +46,7 @@ func Test_sanitizeKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("test sanitizing key names", func(t *testing.T) {
-			if got := sanitizeKey(tt.given); got == tt.expected {
+			if got := sanitizeKey(tt.given); got != tt.expected {
 				t.Errorf("shellName error: want %q, got %q", tt.expected, got)
 			}
 		})

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_validateShellName(t *testing.T) {
+	tests := []struct {
+		name    string
+		str     string
+		wantErr bool
+	}{
+		{name: "strings with spaces should fail", str: "invalid strings", wantErr: true},
+		{name: "strings with only underscores should pass", str: "valid_string", wantErr: false},
+		{name: "strings with dashes should fail", str: "validish-string", wantErr: true},
+		{name: "strings that start with numbers should fail", str: "1invalidstring", wantErr: true},
+		{name: "strings that start with underscores should pass", str: "_1validstring", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateShellName(tt.str); (err != nil) != tt.wantErr {
+				t.Errorf("validateShellName error: %v, expect wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_sanitizeKey(t *testing.T) {
+	tests := []struct {
+		givenName    string
+		expectedName string
+	}{
+		{givenName: "invalid strings", expectedName: "invalid_strings"},
+		{givenName: "extremely  invalid  strings", expectedName: "extremely__invalid__strings"},
+		{givenName: fmt.Sprintf("\nunbelievably\tinvalid\tstrings\n"), expectedName: "unbelievably_invalid_strings"},
+		{givenName: "valid_string", expectedName: "valid_string"},
+		{givenName: "validish-string", expectedName: "validish_string"},
+		// these strings should not be corrected, simply returned as-is
+		{givenName: "1invalidstring", expectedName: "1invalidstring"},
+		{givenName: "_1validstring", expectedName: "_1validstring"},
+	}
+
+	for _, tt := range tests {
+		t.Run("test sanitizing key names", func(t *testing.T) {
+			if got := sanitizeKey(tt.givenName); got != tt.expectedName {
+				t.Errorf("shellName error: want %q, got %q", tt.expectedName, got)
+			}
+		})
+	}
+}

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -30,24 +30,24 @@ func Test_validateShellName(t *testing.T) {
 
 func Test_sanitizeKey(t *testing.T) {
 	tests := []struct {
-		givenName    string
-		expectedName string
+		given    string
+		expected string
 	}{
-		{givenName: "invalid strings", expectedName: "invalid_strings"},
-		{givenName: "extremely  invalid  strings", expectedName: "extremely__invalid__strings"},
-		{givenName: fmt.Sprintf("\nunbelievably\tinvalid\tstrings\n"), expectedName: "unbelievably_invalid_strings"},
-		{givenName: "valid_string", expectedName: "valid_string"},
-		{givenName: "validish-string", expectedName: "validish_string"},
-		// these strings should not be corrected, simply returned as-is
-		{givenName: "1invalidstring", expectedName: "1invalidstring"},
-		{givenName: "_1validstring", expectedName: "_1validstring"},
-		{givenName: "invalid.string", expectedName: "invalid_string"},
+		{given: "invalid strings", expected: "invalid_strings"},
+		{given: "extremely  invalid  strings", expected: "extremely__invalid__strings"},
+		{given: fmt.Sprintf("\nunbelievably\tinvalid\tstrings\n"), expected: "unbelievably_invalid_strings"},
+		{given: "valid_string", expected: "valid_string"},
+		{given: "validish-string", expected: "validish_string"},
+		{given: "valid.string", expected: "valid_string"},
+		// the following two strings should not be corrected, simply returned as-is.
+		{given: "1invalidstring", expected: "1invalidstring"},
+		{given: "_1validstring", expected: "_1validstring"},
 	}
 
 	for _, tt := range tests {
 		t.Run("test sanitizing key names", func(t *testing.T) {
-			if got := sanitizeKey(tt.givenName); got != tt.expectedName {
-				t.Errorf("shellName error: want %q, got %q", tt.expectedName, got)
+			if got := sanitizeKey(tt.given); got == tt.expected {
+				t.Errorf("shellName error: want %q, got %q", tt.expected, got)
 			}
 		})
 	}

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -7,21 +7,22 @@ import (
 
 func Test_validateShellName(t *testing.T) {
 	tests := []struct {
-		name    string
-		str     string
-		wantErr bool
+		name       string
+		str        string
+		shouldFail bool
 	}{
-		{name: "strings with spaces should fail", str: "invalid strings", wantErr: true},
-		{name: "strings with only underscores should pass", str: "valid_string", wantErr: false},
-		{name: "strings with dashes should fail", str: "validish-string", wantErr: true},
-		{name: "strings that start with numbers should fail", str: "1invalidstring", wantErr: true},
-		{name: "strings that start with underscores should pass", str: "_1validstring", wantErr: false},
+		{name: "strings with spaces should fail", str: "invalid strings", shouldFail: true},
+		{name: "strings with only underscores should pass", str: "valid_string", shouldFail: false},
+		{name: "strings with dashes should fail", str: "validish-string", shouldFail: true},
+		{name: "strings that start with numbers should fail", str: "1invalidstring", shouldFail: true},
+		{name: "strings that start with underscores should pass", str: "_1validstring", shouldFail: false},
+		{name: "strings that contain periods should fail", str: "invalid.string", shouldFail: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateShellName(tt.str); (err != nil) != tt.wantErr {
-				t.Errorf("validateShellName error: %v, expect wantErr %v", err, tt.wantErr)
+			if err := validateShellName(tt.str); (err != nil) != tt.shouldFail {
+				t.Errorf("validateShellName error: %v, expect wantErr %v", err, tt.shouldFail)
 			}
 		})
 	}
@@ -40,6 +41,7 @@ func Test_sanitizeKey(t *testing.T) {
 		// these strings should not be corrected, simply returned as-is
 		{givenName: "1invalidstring", expectedName: "1invalidstring"},
 		{givenName: "_1validstring", expectedName: "_1validstring"},
+		{givenName: "invalid.string", expectedName: "invalid_string"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -31,6 +31,7 @@ var (
 )
 
 func init() {
+	exportCmd.Flags().SortFlags = false
 	exportCmd.Flags().StringVarP(&exportFormat, "format", "f", "json", "Output format (json, yaml, java-properties, csv, tsv, dotenv, tfvars)")
 	exportCmd.Flags().StringVarP(&exportOutput, "output-file", "o", "", "Output file (default is standard output)")
 

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -15,27 +15,28 @@ func TestExportDotenv(t *testing.T) {
 		output []string
 	}{
 		{
-			"simple",
-			map[string]string{"foo": "bar"},
-			[]string{`FOO="bar"`},
+			name:   "simple string, simple test",
+			params: map[string]string{"foo": "bar"},
+			output: []string{`FOO="bar"`},
 		},
 		{
-			"escaped dollar",
-			map[string]string{"foo": "bar", "baz": "$qux"},
-			[]string{`FOO="bar"`, `BAZ="\$qux"`},
+			name:   "literal dollar signs should be properly escaped",
+			params: map[string]string{"foo": "bar", "baz": `$qux`},
+			output: []string{`FOO="bar"`, `BAZ="\$qux"`},
 		},
 		{
-			"escaped quote",
-			map[string]string{"foo": "bar", "baz": `"qux"`},
-			[]string{`FOO="bar"`, `BAZ="\"qux\""`},
+			name:   "double quotes should be fully escaped",
+			params: map[string]string{"foo": "bar", "baz": `"qux"`},
+			output: []string{`FOO="bar"`, `BAZ="\"qux\""`},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 			err := exportAsEnvFile(test.params, buf)
+
 			assert.Nil(t, err)
-			assert.ElementsMatch(t, test.output, strings.Split(strings.Trim(buf.String(), "\n"), "\n"))
+			assert.ElementsMatch(t, test.output, strings.Split(strings.TrimSpace(buf.String()), "\n"))
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/segmentio/chamber/v2
 go 1.19
 
 require (
+	github.com/alessio/shellescape v1.4.1
 	github.com/aws/aws-sdk-go v1.44.257
 	github.com/magiconair/properties v1.8.7
 	github.com/segmentio/analytics-go/v3 v3.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/aws/aws-sdk-go v1.44.257 h1:HwelXYZZ8c34uFFhgVw3ybu2gB5fkk8KLj2idTvzZb8=
 github.com/aws/aws-sdk-go v1.44.257/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=


### PR DESCRIPTION
This was reported in https://github.com/segmentio/chamber/issues/366: `chamber` made no effort to sanitize keys for either of these commands or formats, which can result in invalid variable names being used for both of these output formats. This PR fixes half of the problem (invalid characters in retrieved keys when rendered via `env` or `export -f dotenv`) but does not address the larger question of "what is a valid character when writing a key?"

Some of the construction of these formats have now been unified, with an optional boolean flag for `env` to preserve key case -- note that keys will still be sanitized, they just won't be converted to uppercase. Since `export -f dotenv` rewrites values using escape characters, I've made the choice to continue allowing `export -f dotenv` to always convert keys to uppercase.

## New Flags

`chamber env` has received a couple of new flags: `-e, --escape-strings`, `-p, --preserve-case`   :

- `--escape-strings` will allow `chamber env` to print values as either safely quoted string literals or safely quoted escape sequences.
- `--preserve-case` will force `chamber env` to respect whatever case a key originally used

### Before

```
$ chamber env -b s3 --backend-s3-bucket dummy-bucket example-service
export EXAMPLE_PASSWORD=cafeface1337
export EXAMPLE-ACCESS-TOKEN=abcdefghijklmnopqrstuvwxyz
export EXAMPLE-USER=itsamemario
export EXAMPLE-MULTILINE='I have eaten
the plums
that were in
the icebox

and which
you were probably
saving
for breakfast

Forgive me
they were delicious
so sweet
and so cold
'

$ chamber export -f dotenv -b s3 --backend-s3-bucket dummy-bucket example-service
EXAMPLE_PASSWORD="cafeface1337"
EXAMPLE-ACCESS-TOKEN="abcdefghijklmnopqrstuvwxyz"
EXAMPLE-USER="itsamemario"
EXAMPLE-MULTILINE="I have eaten\nthe plums\nthat were in\nthe icebox\n\nand which\nyou were probably\nsaving\nfor breakfast\n\nForgive me\nthey were delicious\nso sweet\nand so cold\n'
```

### After

```
$ chamber env -b s3 --backend-s3-bucket dummy-bucket example-service
export EXAMPLE_PASSWORD=cafeface1337
export EXAMPLE_ACCESS-TOKEN=abcdefghijklmnopqrstuvwxyz
export EXAMPLE_USER=itsamemario
export EXAMPLE_MULTILINE='I have eaten
the plums
that were in
the icebox

and which
you were probably
saving
for breakfast

Forgive me
they were delicious
so sweet
and so cold
'

$ chamber export -f dotenv -b s3 --backend-s3-bucket dummy-bucket example-service
EXAMPLE_PASSWORD="cafeface1337"
EXAMPLE_ACCESS-TOKEN="abcdefghijklmnopqrstuvwxyz"
EXAMPLE_USER="itsamemario"
EXAMPLE_MULTILINE="I have eaten\nthe plums\nthat were in\nthe icebox\n\nand which\nyou were probably\nsaving\nfor breakfast\n\nForgive me\nthey were delicious\nso sweet\nand so cold\n'
```

## What about backwards compatibility?

![ce360a34866ff26bd94c2057a9a9b328](https://github.com/segmentio/chamber/assets/344926/3633b800-a340-4d72-834d-ae0d4ac167ec)

Effort has been taken to preserve the _spirit_ of backwards compatibility with the output formats that these commands have rendered in the past. But since the formats were objectively incorrect, I'm really not worried about it.