### PR TITLE
store: fail faster if not running in EC2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/alessio/shellescape v1.4.1
 	github.com/aws/aws-sdk-go v1.44.312
+	github.com/kevinburke/isec2 v0.1.0
 	github.com/magiconair/properties v1.8.7
 	github.com/segmentio/analytics-go/v3 v3.2.1
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/kevinburke/isec2 v0.1.0 h1:BhEAlWqZR6lNL7o/C3W46mhIBpJHimYNYQtXtvwXk6o=
+github.com/kevinburke/isec2 v0.1.0/go.mod h1:axcGKXslLWfmqxnN+O0NqA8oGKqkQ37MQArV2brBVpw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
If you are running `chamber` outside of EC2 without a region configured, the binary will take 5 seconds to fail because the default ec2 metadata API timeout is 5 seconds.

Instead, take a few milliseconds to determine whether we are even running on EC2. We attempt to do this by checking the contents of different files on the disk, e.g. /sys/devices/virtual/dmi/id/board_asset_tag, and then if all of those fail, attempting to see if anything is listening on the metadata host.

This can help prevent the 5 second failure timeout.