### PR TITLE
chore: update docker build to use golang 1.20.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-alpine AS build
+FROM golang:1.20.9-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .


### PR DESCRIPTION
This is due to CVE-2023-39323 and fixes #428