### PR TITLE
Bump golang from 1.21.2 to 1.21.4 to address CVE-2023-45283

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.2-alpine AS build
+FROM golang:1.21.4-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .


### PR DESCRIPTION
Bump golang from 1.21.2 to 1.21.4 to address CVE-2023-45283:
<img width="527" alt="image" src="https://github.com/segmentio/chamber/assets/10180588/7ebb7648-315f-4666-b317-f5db2d52f606">
