### PR TITLE
Bump docker golang from 1.21.4 to 1.21.5 to address CVE-2023-45285

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4-alpine AS build
+FROM golang:1.21.5-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .


### PR DESCRIPTION
The vulnerability in CVE-2023-45285 could allow for dependencies to be pulled insecurely. This upgrades the go version used in the docker build to prevent that.