### PR TITLE
ci: bump actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Make distributables
         run: make -f Makefile.release dist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ matrix.go }}
           path: "dist/*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Make distributables
         run: make -f Makefile.release dist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: "dist/*"
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: "dist"
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: "dist/*"


### PR DESCRIPTION
### Description

We're seeing some consistent 400 responses in our `dist` steps for our GitHub actions. After doing some digging, it looks like the [v4 version of the Artifacts GitHub Actions](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/) was made available in early December that should resolve and/or make more reliable these actions.

### Changes

The `v4` versions of these actions come with some breaking changes and requirements that are addressed in this PR:
* If we are using `actions/upload-artifacts@v4`, we _**must also**_ be using `actions/download-artifacts@v4`
* Artifact uploads **must** contain unique names.
