### PR TITLE
build: update to Go 1.22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   install-go-modules:
     strategy:
       matrix:
-        go: ["1.21.x", "1.20.x", "1.19.x"]
+        go: ["1.22.x", 1.21.x", "1.20.x"]
 
     runs-on: ubuntu-latest
 
@@ -28,7 +28,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.21.x", "1.20.x", "1.19.x"]
+        go: ["1.22.x", 1.21.x", "1.20.x"]
     runs-on: ubuntu-latest
 
     steps:
@@ -56,7 +56,7 @@ jobs:
   dist:
     strategy:
       matrix:
-        go: ["1.21.x", "1.20.x", "1.19.x"]
+        go: ["1.22.x", "1.21.x", "1.20.x"]
     runs-on: ubuntu-latest
     needs: test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Install nfpm, rpmbuild
         run: sudo make -f Makefile.tools nfpm-debian rpmbuild-debian
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.6-alpine AS build
+FROM golang:1.22.1-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/segmentio/chamber/v2
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alessio/shellescape v1.4.2


### PR DESCRIPTION
Includes:

* Bumping go.mod to minimum Go 1.20
* Updating GitHub build and release workflows to 1.22, and dropping 1.19
* Bumping the Docker base image to Go 1.22.1
