### PR TITLE
refactor!: Properly support contexts

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -51,7 +51,7 @@ func delete(cmd *cobra.Command, args []string) error {
 				Set("backend", backend),
 		})
 	}
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
@@ -60,5 +60,5 @@ func delete(cmd *cobra.Command, args []string) error {
 		Key:     key,
 	}
 
-	return secretStore.Delete(secretId)
+	return secretStore.Delete(cmd.Context(), secretId)
 }

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -64,12 +64,12 @@ func exportEnv(cmd *cobra.Command, args []string) ([]string, error) {
 		return nil, fmt.Errorf("Failed to validate service: %w", err)
 	}
 
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get secret store: %w", err)
 	}
 
-	rawSecrets, err := secretStore.ListRaw(service)
+	rawSecrets, err := secretStore.ListRaw(cmd.Context(), service)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to list store contents: %w", err)
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -92,7 +92,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
@@ -108,7 +108,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		}
 		var err error
 		env = environ.Environ(os.Environ())
-		err = env.LoadStrict(secretStore, strictValue, pristine, services...)
+		err = env.LoadStrict(cmd.Context(), secretStore, strictValue, pristine, services...)
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 			collisions := make([]string, 0)
 			var err error
 			// TODO: these interfaces should look the same as Strict*, so move pristine in there
-			err = env.Load(secretStore, service, &collisions)
+			err = env.Load(cmd.Context(), secretStore, service, &collisions)
 			if err != nil {
 				return fmt.Errorf("Failed to list store contents: %w", err)
 			}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -53,7 +53,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Failed to validate service %s: %w", service, err)
 		}
 
-		rawSecrets, err := secretStore.ListRaw(service)
+		rawSecrets, err := secretStore.ListRaw(cmd.Context(), service)
 		if err != nil {
 			return fmt.Errorf("Failed to list store contents for service %s: %w", service, err)
 		}

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -39,18 +39,18 @@ func find(cmd *cobra.Command, args []string) error {
 		includeSecrets = true
 	}
 
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
-	services, err := secretStore.ListServices(blankService, includeSecrets)
+	services, err := secretStore.ListServices(cmd.Context(), blankService, includeSecrets)
 	if err != nil {
 		return fmt.Errorf("Failed to list store contents: %w", err)
 	}
 
 	if byValue {
 		for _, service := range services {
-			allSecrets, err := secretStore.List(service, true)
+			allSecrets, err := secretStore.List(cmd.Context(), service, true)
 			if err == nil {
 				matches = append(matches, findValueMatch(allSecrets, findSecret)...)
 			}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -47,7 +47,7 @@ func history(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
@@ -56,7 +56,7 @@ func history(cmd *cobra.Command, args []string) error {
 		Key:     key,
 	}
 
-	events, err := secretStore.History(secretId)
+	events, err := secretStore.History(cmd.Context(), secretId)
 	if err != nil {
 		return fmt.Errorf("Failed to get history: %w", err)
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -65,7 +65,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
@@ -78,7 +78,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 			Service: service,
 			Key:     key,
 		}
-		if err := secretStore.Write(secretId, value); err != nil {
+		if err := secretStore.Write(cmd.Context(), secretId, value); err != nil {
 			return fmt.Errorf("Failed to write secret: %w", err)
 		}
 	}

--- a/cmd/list-services.go
+++ b/cmd/list-services.go
@@ -34,11 +34,11 @@ func listServices(cmd *cobra.Command, args []string) error {
 		service = utils.NormalizeService(args[0])
 
 	}
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
-	secrets, err := secretStore.ListServices(service, includeSecretName)
+	secrets, err := secretStore.ListServices(cmd.Context(), service, includeSecretName)
 	if err != nil {
 		return fmt.Errorf("Failed to list store contents: %w", err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -54,11 +54,11 @@ func list(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
-	secrets, err := secretStore.List(service, withValues)
+	secrets, err := secretStore.List(cmd.Context(), service, withValues)
 	if err != nil {
 		return fmt.Errorf("Failed to list store contents: %w", err)
 	}

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -54,7 +54,7 @@ func read(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
@@ -64,7 +64,7 @@ func read(cmd *cobra.Command, args []string) error {
 		Key:     key,
 	}
 
-	secret, err := secretStore.Read(secretId, version)
+	secret, err := secretStore.Read(cmd.Context(), secretId, version)
 	if err != nil {
 		return fmt.Errorf("Failed to read: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -133,7 +134,7 @@ func validateKey(key string) error {
 	return nil
 }
 
-func getSecretStore() (store.Store, error) {
+func getSecretStore(ctx context.Context) (store.Store, error) {
 	rootPflags := RootCmd.PersistentFlags()
 	if backendEnvVarValue := os.Getenv(BackendEnvVar); !rootPflags.Changed("backend") && backendEnvVarValue != "" {
 		backend = backendEnvVarValue
@@ -170,7 +171,7 @@ func getSecretStore() (store.Store, error) {
 		if bucket == "" {
 			return nil, errors.New("Must set bucket for s3 backend")
 		}
-		s, err = store.NewS3StoreWithBucket(numRetries, bucket)
+		s, err = store.NewS3StoreWithBucket(ctx, numRetries, bucket)
 	case S3KMSBackend:
 		var bucket string
 		if bucketEnvVarValue := os.Getenv(BucketEnvVar); !rootPflags.Changed("backend-s3-bucket") && bucketEnvVarValue != "" {
@@ -197,9 +198,9 @@ func getSecretStore() (store.Store, error) {
 			return nil, errors.New("Must set kmsKeyAlias for S3 KMS backend")
 		}
 
-		s, err = store.NewS3KMSStore(numRetries, bucket, kmsKeyAlias)
+		s, err = store.NewS3KMSStore(ctx, numRetries, bucket, kmsKeyAlias)
 	case SecretsManagerBackend:
-		s, err = store.NewSecretsManagerStore(numRetries)
+		s, err = store.NewSecretsManagerStore(ctx, numRetries)
 	case SSMBackend:
 		if kmsKeyAliasFlag != DefaultKMSKey {
 			return nil, errors.New("Unable to use --kms-key-alias with this backend. Use CHAMBER_KMS_KEY_ALIAS instead.")
@@ -209,7 +210,7 @@ func getSecretStore() (store.Store, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Invalid retry mode %s", retryMode)
 		}
-		s, err = store.NewSSMStoreWithRetryMode(numRetries, parsedRetryMode)
+		s, err = store.NewSSMStoreWithRetryMode(ctx, numRetries, parsedRetryMode)
 	default:
 		return nil, fmt.Errorf("invalid backend `%s`", backend)
 	}

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -75,7 +75,7 @@ func write(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	secretStore, err := getSecretStore()
+	secretStore, err := getSecretStore(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
@@ -86,11 +86,11 @@ func write(cmd *cobra.Command, args []string) error {
 	}
 
 	if skipUnchanged {
-		currentSecret, err := secretStore.Read(secretId, -1)
+		currentSecret, err := secretStore.Read(cmd.Context(), secretId, -1)
 		if err == nil && value == *currentSecret.Value {
 			return nil
 		}
 	}
 
-	return secretStore.Write(secretId, value)
+	return secretStore.Write(cmd.Context(), secretId, value)
 }

--- a/environ/environ.go
+++ b/environ/environ.go
@@ -1,6 +1,7 @@
 package environ
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -83,8 +84,8 @@ func normalizeEnvVarName(k string) string {
 
 // load loads environment variables into e from s given a service
 // collisions will be populated with any keys that get overwritten
-func (e *Environ) load(s store.Store, service string, collisions *[]string) error {
-	rawSecrets, err := s.ListRaw(utils.NormalizeService(service))
+func (e *Environ) load(ctx context.Context, s store.Store, service string, collisions *[]string) error {
+	rawSecrets, err := s.ListRaw(ctx, utils.NormalizeService(service))
 	if err != nil {
 		return err
 	}
@@ -104,20 +105,20 @@ func (e *Environ) load(s store.Store, service string, collisions *[]string) erro
 
 // Load loads environment variables into e from s given a service
 // collisions will be populated with any keys that get overwritten
-func (e *Environ) Load(s store.Store, service string, collisions *[]string) error {
-	return e.load(s, service, collisions)
+func (e *Environ) Load(ctx context.Context, s store.Store, service string, collisions *[]string) error {
+	return e.load(ctx, s, service, collisions)
 }
 
 // LoadStrict loads all services from s in strict mode: env vars in e with value equal to valueExpected
 // are the only ones substituted. If there are any env vars in s that are also in e, but don't have their value
 // set to valueExpected, this is an error.
-func (e *Environ) LoadStrict(s store.Store, valueExpected string, pristine bool, services ...string) error {
-	return e.loadStrict(s, valueExpected, pristine, services...)
+func (e *Environ) LoadStrict(ctx context.Context, s store.Store, valueExpected string, pristine bool, services ...string) error {
+	return e.loadStrict(ctx, s, valueExpected, pristine, services...)
 }
 
-func (e *Environ) loadStrict(s store.Store, valueExpected string, pristine bool, services ...string) error {
+func (e *Environ) loadStrict(ctx context.Context, s store.Store, valueExpected string, pristine bool, services ...string) error {
 	for _, service := range services {
-		rawSecrets, err := s.ListRaw(utils.NormalizeService(service))
+		rawSecrets, err := s.ListRaw(ctx, utils.NormalizeService(service))
 		if err != nil {
 			return err
 		}

--- a/store/backendbenchmarks_test.go
+++ b/store/backendbenchmarks_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -36,8 +37,9 @@ func RandStringRunes(n int) string {
 }
 
 func benchmarkStore(t *testing.T, store Store, services []string) {
-	setupStore(t, store, services)
-	defer cleanupStore(t, store, services)
+	ctx := context.Background()
+	setupStore(t, ctx, store, services)
+	defer cleanupStore(t, ctx, store, services)
 
 	concurrentExecs := []int{1, 10, 500, 1000}
 
@@ -47,7 +49,7 @@ func benchmarkStore(t *testing.T, store Store, services []string) {
 
 		for i := 0; i < concurrency; i++ {
 			wg.Add(1)
-			go emulateExec(t, &wg, store, services)
+			go emulateExec(t, ctx, &wg, store, services)
 
 		}
 		wg.Wait()
@@ -56,11 +58,11 @@ func benchmarkStore(t *testing.T, store Store, services []string) {
 	}
 }
 
-func emulateExec(t *testing.T, wg *sync.WaitGroup, s Store, services []string) error {
+func emulateExec(t *testing.T, ctx context.Context, wg *sync.WaitGroup, s Store, services []string) error {
 	defer wg.Done()
 	// Exec calls ListRaw once per service specified
 	for _, service := range services {
-		_, err := s.ListRaw(service)
+		_, err := s.ListRaw(ctx, service)
 		if err != nil {
 			t.Logf("Failed to execute ListRaw: %s", err)
 			return err
@@ -73,7 +75,7 @@ func TestS3StoreConcurrency(t *testing.T) {
 	if !benchmarkEnabled {
 		t.SkipNow()
 	}
-	s, _ := NewS3StoreWithBucket(10, "chamber-test")
+	s, _ := NewS3StoreWithBucket(context.Background(), 10, "chamber-test")
 	benchmarkStore(t, s, []string{"foo"})
 }
 
@@ -81,7 +83,7 @@ func TestSecretsManagerStoreConcurrency(t *testing.T) {
 	if !benchmarkEnabled {
 		t.SkipNow()
 	}
-	s, _ := NewSecretsManagerStore(10)
+	s, _ := NewSecretsManagerStore(context.Background(), 10)
 	benchmarkStore(t, s, []string{"foo"})
 }
 
@@ -90,11 +92,11 @@ func TestSSMConcurrency(t *testing.T) {
 		t.SkipNow()
 	}
 
-	s, _ := NewSSMStore(10)
+	s, _ := NewSSMStore(context.Background(), 10)
 	benchmarkStore(t, s, []string{"foo"})
 }
 
-func setupStore(t *testing.T, store Store, services []string) {
+func setupStore(t *testing.T, ctx context.Context, store Store, services []string) {
 	// populate the store for services listed
 	for _, service := range services {
 		for i := 0; i < KeysPerService; i++ {
@@ -104,12 +106,12 @@ func setupStore(t *testing.T, store Store, services []string) {
 				Key:     key,
 			}
 
-			store.Write(id, RandStringRunes(100))
+			store.Write(ctx, id, RandStringRunes(100))
 		}
 	}
 }
 
-func cleanupStore(t *testing.T, store Store, services []string) {
+func cleanupStore(t *testing.T, ctx context.Context, store Store, services []string) {
 	for _, service := range services {
 		for i := 0; i < KeysPerService; i++ {
 			key := fmt.Sprintf("var%d", i)
@@ -118,7 +120,7 @@ func cleanupStore(t *testing.T, store Store, services []string) {
 				Key:     key,
 			}
 
-			store.Delete(id)
+			store.Delete(ctx, id)
 		}
 	}
 }

--- a/store/nullstore.go
+++ b/store/nullstore.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"errors"
 )
 
@@ -12,30 +13,30 @@ func NewNullStore() *NullStore {
 	return &NullStore{}
 }
 
-func (s *NullStore) Write(id SecretId, value string) error {
+func (s *NullStore) Write(ctx context.Context, id SecretId, value string) error {
 	return errors.New("Write is not implemented for Null Store")
 }
 
-func (s *NullStore) Read(id SecretId, version int) (Secret, error) {
+func (s *NullStore) Read(ctx context.Context, id SecretId, version int) (Secret, error) {
 	return Secret{}, errors.New("Not implemented for Null Store")
 }
 
-func (s *NullStore) ListServices(service string, includeSecretNames bool) ([]string, error) {
+func (s *NullStore) ListServices(ctx context.Context, service string, includeSecretNames bool) ([]string, error) {
 	return nil, nil
 }
 
-func (s *NullStore) List(service string, includeValues bool) ([]Secret, error) {
+func (s *NullStore) List(ctx context.Context, service string, includeValues bool) ([]Secret, error) {
 	return []Secret{}, nil
 }
 
-func (s *NullStore) ListRaw(service string) ([]RawSecret, error) {
+func (s *NullStore) ListRaw(ctx context.Context, service string) ([]RawSecret, error) {
 	return []RawSecret{}, nil
 }
 
-func (s *NullStore) History(id SecretId) ([]ChangeEvent, error) {
+func (s *NullStore) History(ctx context.Context, id SecretId) ([]ChangeEvent, error) {
 	return []ChangeEvent{}, nil
 }
 
-func (s *NullStore) Delete(id SecretId) error {
+func (s *NullStore) Delete(ctx context.Context, id SecretId) error {
 	return errors.New("Not implemented for Null Store")
 }

--- a/store/secretsmanagerstore.go
+++ b/store/secretsmanagerstore.go
@@ -80,8 +80,8 @@ type SecretsManagerStore struct {
 }
 
 // NewSecretsManagerStore creates a new SecretsManagerStore
-func NewSecretsManagerStore(numRetries int) (*SecretsManagerStore, error) {
-	cfg, _, err := getConfig(numRetries, aws.RetryModeStandard)
+func NewSecretsManagerStore(ctx context.Context, numRetries int) (*SecretsManagerStore, error) {
+	cfg, _, err := getConfig(ctx, numRetries, aws.RetryModeStandard)
 	if err != nil {
 		return nil, err
 	}
@@ -99,10 +99,10 @@ func NewSecretsManagerStore(numRetries int) (*SecretsManagerStore, error) {
 
 // Write writes a given value to a secret identified by id. If the secret
 // already exists, then write a new version.
-func (s *SecretsManagerStore) Write(id SecretId, value string) error {
+func (s *SecretsManagerStore) Write(ctx context.Context, id SecretId, value string) error {
 	version := 1
 	// first read to get the current version
-	latest, err := s.readLatest(id.Service)
+	latest, err := s.readLatest(ctx, id.Service)
 	mustCreate := false
 	deleteKeyFromSecret := len(value) == 0
 
@@ -146,7 +146,7 @@ func (s *SecretsManagerStore) Write(id SecretId, value string) error {
 		}
 		latest[metadataKey] = rawMetadata
 	} else {
-		user, err := s.getCurrentUser()
+		user, err := s.getCurrentUser(ctx)
 		if err != nil {
 			return err
 		}
@@ -185,7 +185,7 @@ func (s *SecretsManagerStore) Write(id SecretId, value string) error {
 			Name:         aws.String(id.Service),
 			SecretString: aws.String(string(contents)),
 		}
-		_, err = s.svc.CreateSecret(context.TODO(), createSecretValueInput)
+		_, err = s.svc.CreateSecret(ctx, createSecretValueInput)
 		if err != nil {
 			return err
 		}
@@ -195,7 +195,7 @@ func (s *SecretsManagerStore) Write(id SecretId, value string) error {
 		describeSecretInput := &secretsmanager.DescribeSecretInput{
 			SecretId: aws.String(id.Service),
 		}
-		details, err := s.svc.DescribeSecret(context.TODO(), describeSecretInput)
+		details, err := s.svc.DescribeSecret(ctx, describeSecretInput)
 		if err != nil {
 			return err
 		}
@@ -208,7 +208,7 @@ func (s *SecretsManagerStore) Write(id SecretId, value string) error {
 			SecretString:  aws.String(string(contents)),
 			VersionStages: []string{"AWSCURRENT", "CHAMBER" + fmt.Sprint(version)},
 		}
-		_, err = s.svc.PutSecretValue(context.TODO(), putSecretValueInput)
+		_, err = s.svc.PutSecretValue(ctx, putSecretValueInput)
 		if err != nil {
 			return err
 		}
@@ -219,9 +219,9 @@ func (s *SecretsManagerStore) Write(id SecretId, value string) error {
 
 // Read reads a secret at a specific version.
 // To grab the latest version, use -1 as the version number.
-func (s *SecretsManagerStore) Read(id SecretId, version int) (Secret, error) {
+func (s *SecretsManagerStore) Read(ctx context.Context, id SecretId, version int) (Secret, error) {
 	if version == -1 {
-		latest, err := s.readLatest(id.Service)
+		latest, err := s.readLatest(ctx, id.Service)
 		if err != nil {
 			return Secret{}, err
 		}
@@ -247,23 +247,23 @@ func (s *SecretsManagerStore) Read(id SecretId, version int) (Secret, error) {
 		}, nil
 
 	}
-	return s.readVersion(id, version)
+	return s.readVersion(ctx, id, version)
 }
 
 // Delete removes a secret. Note this removes all versions of the secret. (True?)
-func (s *SecretsManagerStore) Delete(id SecretId) error {
+func (s *SecretsManagerStore) Delete(ctx context.Context, id SecretId) error {
 	// delegate to Write
-	return s.Write(id, "")
+	return s.Write(ctx, id, "")
 }
 
-func (s *SecretsManagerStore) readVersion(id SecretId, version int) (Secret, error) {
+func (s *SecretsManagerStore) readVersion(ctx context.Context, id SecretId, version int) (Secret, error) {
 	listSecretVersionIdsInput := &secretsmanager.ListSecretVersionIdsInput{
 		SecretId:          aws.String(id.Service),
 		IncludeDeprecated: aws.Bool(false),
 	}
 
 	var result Secret
-	resp, err := s.svc.ListSecretVersionIds(context.TODO(), listSecretVersionIdsInput)
+	resp, err := s.svc.ListSecretVersionIds(ctx, listSecretVersionIdsInput)
 	if err != nil {
 		return Secret{}, err
 	}
@@ -277,7 +277,7 @@ func (s *SecretsManagerStore) readVersion(id SecretId, version int) (Secret, err
 			VersionId: h.VersionId,
 		}
 
-		resp, err := s.svc.GetSecretValue(context.TODO(), getSecretValueInput)
+		resp, err := s.svc.GetSecretValue(ctx, getSecretValueInput)
 
 		if err != nil {
 			return Secret{}, err
@@ -324,12 +324,12 @@ func (s *SecretsManagerStore) readVersion(id SecretId, version int) (Secret, err
 	return Secret{}, ErrSecretNotFound
 }
 
-func (s *SecretsManagerStore) readLatest(service string) (secretValueObject, error) {
+func (s *SecretsManagerStore) readLatest(ctx context.Context, service string) (secretValueObject, error) {
 	getSecretValueInput := &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(service),
 	}
 
-	resp, err := s.svc.GetSecretValue(context.TODO(), getSecretValueInput)
+	resp, err := s.svc.GetSecretValue(ctx, getSecretValueInput)
 
 	if err != nil {
 		return secretValueObject{}, err
@@ -348,17 +348,17 @@ func (s *SecretsManagerStore) readLatest(service string) (secretValueObject, err
 }
 
 // ListServices (not implemented)
-func (s *SecretsManagerStore) ListServices(service string, includeSecretName bool) ([]string, error) {
+func (s *SecretsManagerStore) ListServices(ctx context.Context, service string, includeSecretName bool) ([]string, error) {
 	return nil, fmt.Errorf("Secrets Manager Backend is experimental and does not implement this command")
 }
 
 // List lists all secrets for a given service.  If includeValues is true,
 // then those secrets are decrypted and returned, otherwise only the metadata
 // about a secret is returned.
-func (s *SecretsManagerStore) List(serviceName string, includeValues bool) ([]Secret, error) {
+func (s *SecretsManagerStore) List(ctx context.Context, serviceName string, includeValues bool) ([]Secret, error) {
 	secrets := map[string]Secret{}
 
-	latest, err := s.readLatest(serviceName)
+	latest, err := s.readLatest(ctx, serviceName)
 	if err != nil {
 		return nil, err
 	}
@@ -399,8 +399,8 @@ func (s *SecretsManagerStore) List(serviceName string, includeValues bool) ([]Se
 
 // ListRaw lists all secrets keys and values for a given service. Does not include any
 // other metadata. Suitable for use in production environments.
-func (s *SecretsManagerStore) ListRaw(serviceName string) ([]RawSecret, error) {
-	latest, err := s.readLatest(serviceName)
+func (s *SecretsManagerStore) ListRaw(ctx context.Context, serviceName string) ([]RawSecret, error) {
+	latest, err := s.readLatest(ctx, serviceName)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +420,7 @@ func (s *SecretsManagerStore) ListRaw(serviceName string) ([]RawSecret, error) {
 
 // History returns a list of events that have occurred regarding the given
 // secret.
-func (s *SecretsManagerStore) History(id SecretId) ([]ChangeEvent, error) {
+func (s *SecretsManagerStore) History(ctx context.Context, id SecretId) ([]ChangeEvent, error) {
 	events := []ChangeEvent{}
 
 	listSecretVersionIdsInput := &secretsmanager.ListSecretVersionIdsInput{
@@ -428,7 +428,7 @@ func (s *SecretsManagerStore) History(id SecretId) ([]ChangeEvent, error) {
 		IncludeDeprecated: aws.Bool(false),
 	}
 
-	resp, err := s.svc.ListSecretVersionIds(context.TODO(), listSecretVersionIdsInput)
+	resp, err := s.svc.ListSecretVersionIds(ctx, listSecretVersionIdsInput)
 	if err != nil {
 		return events, err
 	}
@@ -445,7 +445,7 @@ func (s *SecretsManagerStore) History(id SecretId) ([]ChangeEvent, error) {
 			VersionId: h.VersionId,
 		}
 
-		resp, err := s.svc.GetSecretValue(context.TODO(), getSecretValueInput)
+		resp, err := s.svc.GetSecretValue(ctx, getSecretValueInput)
 
 		if err != nil {
 			return events, err
@@ -498,8 +498,8 @@ func (s *SecretsManagerStore) History(id SecretId) ([]ChangeEvent, error) {
 	return events, nil
 }
 
-func (s *SecretsManagerStore) getCurrentUser() (string, error) {
-	resp, err := s.stsSvc.GetCallerIdentity(context.TODO(), &sts.GetCallerIdentityInput{})
+func (s *SecretsManagerStore) getCurrentUser(ctx context.Context) (string, error) {
+	resp, err := s.stsSvc.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		return "", err
 	}

--- a/store/secretsmanagerstore_test.go
+++ b/store/secretsmanagerstore_test.go
@@ -180,7 +180,7 @@ func TestNewSecretsManagerStore(t *testing.T) {
 		os.Setenv("AWS_DEFAULT_REGION", "us-west-2")
 		defer os.Unsetenv("AWS_DEFAULT_REGION")
 
-		s, err := NewSecretsManagerStore(1)
+		s, err := NewSecretsManagerStore(context.Background(), 1)
 		assert.Nil(t, err)
 		assert.Equal(t, "us-east-1", s.config.Region)
 	})
@@ -189,7 +189,7 @@ func TestNewSecretsManagerStore(t *testing.T) {
 		os.Setenv("AWS_REGION", "us-west-1")
 		defer os.Unsetenv("AWS_REGION")
 
-		s, err := NewSecretsManagerStore(1)
+		s, err := NewSecretsManagerStore(context.Background(), 1)
 		assert.Nil(t, err)
 		assert.Equal(t, "us-west-1", s.config.Region)
 	})
@@ -198,7 +198,7 @@ func TestNewSecretsManagerStore(t *testing.T) {
 		os.Setenv("CHAMBER_AWS_SSM_ENDPOINT", "mycustomendpoint")
 		defer os.Unsetenv("CHAMBER_AWS_SSM_ENDPOINT")
 
-		s, err := NewSecretsManagerStore(1)
+		s, err := NewSecretsManagerStore(context.Background(), 1)
 		assert.Nil(t, err)
 		endpoint, err := s.config.EndpointResolverWithOptions.ResolveEndpoint(secretsmanager.ServiceID, "us-west-2")
 		assert.Nil(t, err)
@@ -206,7 +206,7 @@ func TestNewSecretsManagerStore(t *testing.T) {
 	})
 
 	t.Run("Should use default AWS SSM endpoint if CHAMBER_AWS_SSM_ENDPOINT not set", func(t *testing.T) {
-		s, err := NewSecretsManagerStore(1)
+		s, err := NewSecretsManagerStore(context.Background(), 1)
 		assert.Nil(t, err)
 		_, err = s.config.EndpointResolverWithOptions.ResolveEndpoint(secretsmanager.ServiceID, "us-west-2")
 		var notFoundError *aws.EndpointNotFoundError
@@ -215,6 +215,7 @@ func TestNewSecretsManagerStore(t *testing.T) {
 }
 
 func TestSecretsManagerWrite(t *testing.T) {
+	ctx := context.Background()
 	secrets := make(map[string]mockSecret)
 	outputs := make(map[string]secretsmanager.DescribeSecretOutput)
 	store := NewTestSecretsManagerStore(secrets, outputs)
@@ -222,7 +223,7 @@ func TestSecretsManagerWrite(t *testing.T) {
 	t.Run("Setting a new key should work", func(t *testing.T) {
 		key := "mykey"
 		secretId := SecretId{Service: "test", Key: key}
-		err := store.Write(secretId, "value")
+		err := store.Write(ctx, secretId, "value")
 		assert.Nil(t, err)
 		assert.Contains(t, secrets, secretId.Service)
 		assert.Equal(t, "value", (*secrets[secretId.Service].currentSecret)[key])
@@ -235,7 +236,7 @@ func TestSecretsManagerWrite(t *testing.T) {
 	t.Run("Setting a key twice should create a new version", func(t *testing.T) {
 		key := "multipleversions"
 		secretId := SecretId{Service: "test", Key: key}
-		err := store.Write(secretId, "value")
+		err := store.Write(ctx, secretId, "value")
 		assert.Nil(t, err)
 		assert.Contains(t, secrets, secretId.Service)
 		assert.Equal(t, "value", (*secrets[secretId.Service].currentSecret)[key])
@@ -244,7 +245,7 @@ func TestSecretsManagerWrite(t *testing.T) {
 		assert.Equal(t, 1, keyMetadata.Version)
 		assert.Equal(t, 2, len(secrets[secretId.Service].history))
 
-		err = store.Write(secretId, "newvalue")
+		err = store.Write(ctx, secretId, "newvalue")
 		assert.Nil(t, err)
 		assert.Contains(t, secrets, secretId.Service)
 		assert.Equal(t, "newvalue", (*secrets[secretId.Service].currentSecret)[key])
@@ -259,52 +260,54 @@ func TestSecretsManagerWrite(t *testing.T) {
 		secrets[service] = mockSecret{}
 		outputs[service] = secretsmanager.DescribeSecretOutput{RotationEnabled: aws.Bool(true)}
 		secretId := SecretId{Service: service, Key: "doesnotmatter"}
-		err := store.Write(secretId, "value")
+		err := store.Write(ctx, secretId, "value")
 		assert.EqualError(t, err, "Cannot write to a secret with rotation enabled")
 	})
 }
 
 func TestSecretsManagerRead(t *testing.T) {
+	ctx := context.Background()
 	secrets := make(map[string]mockSecret)
 	outputs := make(map[string]secretsmanager.DescribeSecretOutput)
 	store := NewTestSecretsManagerStore(secrets, outputs)
 	secretId := SecretId{Service: "test", Key: "key"}
-	store.Write(secretId, "value")
-	store.Write(secretId, "second value")
-	store.Write(secretId, "third value")
+	store.Write(ctx, secretId, "value")
+	store.Write(ctx, secretId, "second value")
+	store.Write(ctx, secretId, "third value")
 
 	t.Run("Reading the latest value should work", func(t *testing.T) {
-		s, err := store.Read(secretId, -1)
+		s, err := store.Read(ctx, secretId, -1)
 		assert.Nil(t, err)
 		assert.Equal(t, "third value", *s.Value)
 	})
 
 	t.Run("Reading specific versiosn should work", func(t *testing.T) {
-		first, err := store.Read(secretId, 1)
+		first, err := store.Read(ctx, secretId, 1)
 		assert.Nil(t, err)
 		assert.Equal(t, "value", *first.Value)
 
-		second, err := store.Read(secretId, 2)
+		second, err := store.Read(ctx, secretId, 2)
 		assert.Nil(t, err)
 		assert.Equal(t, "second value", *second.Value)
 
-		third, err := store.Read(secretId, 3)
+		third, err := store.Read(ctx, secretId, 3)
 		assert.Nil(t, err)
 		assert.Equal(t, "third value", *third.Value)
 	})
 
 	t.Run("Reading a non-existent key should give not found err", func(t *testing.T) {
-		_, err := store.Read(SecretId{Service: "test", Key: "nope"}, -1)
+		_, err := store.Read(ctx, SecretId{Service: "test", Key: "nope"}, -1)
 		assert.Equal(t, ErrSecretNotFound, err)
 	})
 
 	t.Run("Reading a non-existent version should give not found error", func(t *testing.T) {
-		_, err := store.Read(secretId, 30)
+		_, err := store.Read(ctx, secretId, 30)
 		assert.Equal(t, ErrSecretNotFound, err)
 	})
 }
 
 func TestSecretsManagerList(t *testing.T) {
+	ctx := context.Background()
 	secrets := make(map[string]mockSecret)
 	outputs := make(map[string]secretsmanager.DescribeSecretOutput)
 	store := NewTestSecretsManagerStore(secrets, outputs)
@@ -315,11 +318,11 @@ func TestSecretsManagerList(t *testing.T) {
 		{Service: "test", Key: "c"},
 	}
 	for _, secret := range testSecrets {
-		store.Write(secret, "value")
+		store.Write(ctx, secret, "value")
 	}
 
 	t.Run("List should return all keys for a service", func(t *testing.T) {
-		s, err := store.List("test", false)
+		s, err := store.List(ctx, "test", false)
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(s))
 		sort.Sort(ByKey(s))
@@ -329,7 +332,7 @@ func TestSecretsManagerList(t *testing.T) {
 	})
 
 	t.Run("List should not return values if includeValues is false", func(t *testing.T) {
-		s, err := store.List("test", false)
+		s, err := store.List(ctx, "test", false)
 		assert.Nil(t, err)
 		for _, secret := range s {
 			assert.Nil(t, secret.Value)
@@ -337,7 +340,7 @@ func TestSecretsManagerList(t *testing.T) {
 	})
 
 	t.Run("List should return values if includeValues is true", func(t *testing.T) {
-		s, err := store.List("test", true)
+		s, err := store.List(ctx, "test", true)
 		assert.Nil(t, err)
 		for _, secret := range s {
 			assert.Equal(t, "value", *secret.Value)
@@ -345,10 +348,10 @@ func TestSecretsManagerList(t *testing.T) {
 	})
 
 	t.Run("List should only return exact matches on service name", func(t *testing.T) {
-		store.Write(SecretId{Service: "match", Key: "a"}, "val")
-		store.Write(SecretId{Service: "matchlonger", Key: "a"}, "val")
+		store.Write(ctx, SecretId{Service: "match", Key: "a"}, "val")
+		store.Write(ctx, SecretId{Service: "matchlonger", Key: "a"}, "val")
 
-		s, err := store.List("match", false)
+		s, err := store.List(ctx, "match", false)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(s))
 		assert.Equal(t, "a", s[0].Meta.Key)
@@ -356,6 +359,7 @@ func TestSecretsManagerList(t *testing.T) {
 }
 
 func TestSecretsManagerListRaw(t *testing.T) {
+	ctx := context.Background()
 	secrets := make(map[string]mockSecret)
 	outputs := make(map[string]secretsmanager.DescribeSecretOutput)
 	store := NewTestSecretsManagerStore(secrets, outputs)
@@ -366,11 +370,11 @@ func TestSecretsManagerListRaw(t *testing.T) {
 		{Service: "test", Key: "c"},
 	}
 	for _, secret := range testSecrets {
-		store.Write(secret, "value")
+		store.Write(ctx, secret, "value")
 	}
 
 	t.Run("ListRaw should return all keys and values for a service", func(t *testing.T) {
-		s, err := store.ListRaw("test")
+		s, err := store.ListRaw(ctx, "test")
 		assert.Nil(t, err)
 		sort.Sort(ByKeyRaw(s))
 		s = s[1:]
@@ -385,10 +389,10 @@ func TestSecretsManagerListRaw(t *testing.T) {
 	})
 
 	t.Run("List should only return exact matches on service name", func(t *testing.T) {
-		store.Write(SecretId{Service: "match", Key: "a"}, "val")
-		store.Write(SecretId{Service: "matchlonger", Key: "a"}, "val")
+		store.Write(ctx, SecretId{Service: "match", Key: "a"}, "val")
+		store.Write(ctx, SecretId{Service: "matchlonger", Key: "a"}, "val")
 
-		s, err := store.ListRaw("match")
+		s, err := store.ListRaw(ctx, "match")
 		sort.Sort(ByKeyRaw(s))
 		s = s[1:]
 		assert.Nil(t, err)
@@ -398,6 +402,7 @@ func TestSecretsManagerListRaw(t *testing.T) {
 }
 
 func TestSecretsManagerHistory(t *testing.T) {
+	ctx := context.Background()
 	secrets := make(map[string]mockSecret)
 	outputs := make(map[string]secretsmanager.DescribeSecretOutput)
 	store := NewTestSecretsManagerStore(secrets, outputs)
@@ -410,23 +415,23 @@ func TestSecretsManagerHistory(t *testing.T) {
 	}
 
 	for _, s := range testSecrets {
-		store.Write(s, "value")
+		store.Write(ctx, s, "value")
 	}
 
 	t.Run("History for a non-existent key should return not found error", func(t *testing.T) {
-		_, err := store.History(SecretId{Service: "test", Key: "nope"})
+		_, err := store.History(ctx, SecretId{Service: "test", Key: "nope"})
 		assert.Equal(t, ErrSecretNotFound, err)
 	})
 
 	t.Run("History should return a single created event for new keys", func(t *testing.T) {
-		events, err := store.History(SecretId{Service: "test", Key: "new"})
+		events, err := store.History(ctx, SecretId{Service: "test", Key: "new"})
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(events))
 		assert.Equal(t, Created, events[0].Type)
 	})
 
 	t.Run("History should return create followed by updates for keys that have been updated", func(t *testing.T) {
-		events, err := store.History(SecretId{Service: "test", Key: "update"})
+		events, err := store.History(ctx, SecretId{Service: "test", Key: "update"})
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(events))
 		assert.Equal(t, Created, events[0].Type)
@@ -436,22 +441,23 @@ func TestSecretsManagerHistory(t *testing.T) {
 }
 
 func TestSecretsManagerDelete(t *testing.T) {
+	ctx := context.Background()
 	secrets := make(map[string]mockSecret)
 	outputs := make(map[string]secretsmanager.DescribeSecretOutput)
 	store := NewTestSecretsManagerStore(secrets, outputs)
 
 	secretId := SecretId{Service: "test", Key: "key"}
-	store.Write(secretId, "value")
+	store.Write(ctx, secretId, "value")
 
 	t.Run("Deleting secret should work", func(t *testing.T) {
-		err := store.Delete(secretId)
+		err := store.Delete(ctx, secretId)
 		assert.Nil(t, err)
-		err = store.Delete(secretId)
+		err = store.Delete(ctx, secretId)
 		assert.Equal(t, ErrSecretNotFound, err)
 	})
 
 	t.Run("Deleting missing secret should fail", func(t *testing.T) {
-		err := store.Delete(SecretId{Service: "test", Key: "nonkey"})
+		err := store.Delete(ctx, SecretId{Service: "test", Key: "nonkey"})
 		assert.Equal(t, ErrSecretNotFound, err)
 	})
 }

--- a/store/shared_test.go
+++ b/store/shared_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestGetConfig(t *testing.T) {
 		defer os.Unsetenv(RegionEnvVar)
 	}
 
-	config, region, err := getConfig(3, aws.RetryModeStandard)
+	config, region, err := getConfig(context.Background(), 3, aws.RetryModeStandard)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "us-west-2", region)

--- a/store/store.go
+++ b/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -59,11 +60,11 @@ type ChangeEvent struct {
 }
 
 type Store interface {
-	Write(id SecretId, value string) error
-	Read(id SecretId, version int) (Secret, error)
-	List(service string, includeValues bool) ([]Secret, error)
-	ListRaw(service string) ([]RawSecret, error)
-	ListServices(service string, includeSecretName bool) ([]string, error)
-	History(id SecretId) ([]ChangeEvent, error)
-	Delete(id SecretId) error
+	Write(ctx context.Context, id SecretId, value string) error
+	Read(ctx context.Context, id SecretId, version int) (Secret, error)
+	List(ctx context.Context, service string, includeValues bool) ([]Secret, error)
+	ListRaw(ctx context.Context, service string) ([]RawSecret, error)
+	ListServices(ctx context.Context, service string, includeSecretName bool) ([]string, error)
+	History(ctx context.Context, id SecretId) ([]ChangeEvent, error)
+	Delete(ctx context.Context, id SecretId) error
 }


### PR DESCRIPTION
The new AWS SDK uses contexts for all API functions and for loading the
SDK configuration. When chamber was migrated to the SDK, all of them
were set to `context.TODO()`. This commit removes those temporary values
and threads contexts properly throughout the codebase, starting from the
chamber commands.

BREAKING CHANGE: This commit changes the signature of many exported
functions to add a context argument.