### PR TITLE
chore!: Remove deprecated support for non-path SSM API

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -96,7 +96,6 @@ func execRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to get secret store: %w", err)
 	}
-	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
 
 	if pristine && verbose {
 		fmt.Fprintf(os.Stderr, "chamber: pristine mode engaged\n")
@@ -109,11 +108,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		}
 		var err error
 		env = environ.Environ(os.Environ())
-		if noPaths {
-			err = env.LoadStrictNoPaths(secretStore, strictValue, pristine, services...)
-		} else {
-			err = env.LoadStrict(secretStore, strictValue, pristine, services...)
-		}
+		err = env.LoadStrict(secretStore, strictValue, pristine, services...)
 		if err != nil {
 			return err
 		}
@@ -125,11 +120,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 			collisions := make([]string, 0)
 			var err error
 			// TODO: these interfaces should look the same as Strict*, so move pristine in there
-			if noPaths {
-				err = env.LoadNoPaths(secretStore, service, &collisions)
-			} else {
-				err = env.Load(secretStore, service, &collisions)
-			}
+			err = env.Load(secretStore, service, &collisions)
 			if err != nil {
 				return fmt.Errorf("Failed to list store contents: %w", err)
 			}

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -108,11 +108,7 @@ func findValueMatch(secrets []store.Secret, searchTerm string) []store.SecretId 
 }
 
 func path(s string) string {
-	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
 	sep := "/"
-	if noPaths {
-		sep = "."
-	}
 
 	tokens := strings.Split(s, sep)
 	secretPath := strings.Join(tokens[1:len(tokens)-1], "/")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -99,11 +99,7 @@ func list(cmd *cobra.Command, args []string) error {
 }
 
 func key(s string) string {
-	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
 	sep := "/"
-	if noPaths {
-		sep = "."
-	}
 
 	tokens := strings.Split(s, sep)
 	secretKey := tokens[len(tokens)-1]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,9 +18,7 @@ import (
 // Regex's used to validate service and key names
 var (
 	validKeyFormat                  = regexp.MustCompile(`^[\w\-\.]+$`)
-	validServiceFormat              = regexp.MustCompile(`^[\w\-\.]+$`)
 	validServicePathFormat          = regexp.MustCompile(`^[\w\-\.]+(\/[\w\-\.]+)*$`)
-	validServiceFormatWithLabel     = regexp.MustCompile(`^[\w\-\.\:]+$`)
 	validServicePathFormatWithLabel = regexp.MustCompile(`^[\w\-\.]+((\/[\w\-\.]+)+(\:[\w\-\.]+)*)?$`)
 
 	verbose    bool
@@ -113,30 +111,16 @@ func Execute(vers string, writeKey string) {
 }
 
 func validateService(service string) error {
-	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
-	if noPaths {
-		if !validServiceFormat.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, full stops and underscores are allowed for service names", service)
-		}
-	} else {
-		if !validServicePathFormat.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, forward slashes, full stops and underscores are allowed for service names. Service names must not start or end with a forward slash", service)
-		}
+	if !validServicePathFormat.MatchString(service) {
+		return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, forward slashes, full stops and underscores are allowed for service names. Service names must not start or end with a forward slash", service)
 	}
 
 	return nil
 }
 
 func validateServiceWithLabel(service string) error {
-	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
-	if noPaths {
-		if !validServiceFormatWithLabel.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, full stops and underscores are allowed for service names, and colon followed by a label name", service)
-		}
-	} else {
-		if !validServicePathFormatWithLabel.MatchString(service) {
-			return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, forward slashes, full stops and underscores are allowed for service names, and colon followed by a label name. Service names must not start or end with a forward slash or colon", service)
-		}
+	if !validServicePathFormatWithLabel.MatchString(service) {
+		return fmt.Errorf("Failed to validate service name '%s'. Only alphanumeric, dashes, forward slashes, full stops and underscores are allowed for service names, and colon followed by a label name. Service names must not start or end with a forward slash or colon", service)
 	}
 
 	return nil

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,41 +71,6 @@ func TestValidations(t *testing.T) {
 			assert.Error(t, result)
 		})
 	}
-
-	// Test Service format without PATH
-	os.Setenv("CHAMBER_NO_PATHS", "true")
-	validServiceNoPathFormat := []string{
-		"foo",
-		"foo.",
-		".foo",
-		"foo.bar",
-		"foo-bar",
-		"foo-bar.foo",
-		"foo-bar.foo-bar",
-		"foo.bar.foo",
-		"foo.bar.foo-bar",
-	}
-
-	for _, k := range validServiceNoPathFormat {
-		t.Run("Service without PATH validation should return Nil", func(t *testing.T) {
-			result := validateService(k)
-			assert.Nil(t, result)
-		})
-	}
-
-	invalidServiceNoPathFormat := []string{
-		"/foo",
-		"foo//bar",
-		"foo/bar",
-	}
-
-	for _, k := range invalidServiceNoPathFormat {
-		t.Run("Service without PATH validation should return Error", func(t *testing.T) {
-			result := validateService(k)
-			assert.Error(t, result)
-		})
-	}
-	os.Unsetenv("CHAMBER_NO_PATHS")
 
 	// Test Service format with PATH and Label
 	validServicePathFormatWithLabel := []string{

--- a/environ/environ.go
+++ b/environ/environ.go
@@ -65,19 +65,16 @@ func fromMap(m map[string]string) Environ {
 }
 
 // like cmd/list.key, but without the env var lookup
-func key(s string, noPaths bool) string {
+func key(s string) string {
 	sep := "/"
-	if noPaths {
-		sep = "."
-	}
 	tokens := strings.Split(s, sep)
 	secretKey := tokens[len(tokens)-1]
 	return secretKey
 }
 
 // transforms a secret key to an env var name, i.e. upppercase, substitute `-` -> `_`
-func secretKeyToEnvVarName(k string, noPaths bool) string {
-	return normalizeEnvVarName(key(k, noPaths))
+func secretKeyToEnvVarName(k string) string {
+	return normalizeEnvVarName(key(k))
 }
 
 func normalizeEnvVarName(k string) string {
@@ -86,15 +83,14 @@ func normalizeEnvVarName(k string) string {
 
 // load loads environment variables into e from s given a service
 // collisions will be populated with any keys that get overwritten
-// noPaths enables the behavior as if CHAMBER_NO_PATHS had been set
-func (e *Environ) load(s store.Store, service string, collisions *[]string, noPaths bool) error {
+func (e *Environ) load(s store.Store, service string, collisions *[]string) error {
 	rawSecrets, err := s.ListRaw(utils.NormalizeService(service))
 	if err != nil {
 		return err
 	}
 	envVarKeys := make([]string, 0)
 	for _, rawSecret := range rawSecrets {
-		envVarKey := secretKeyToEnvVarName(rawSecret.Key, noPaths)
+		envVarKey := secretKeyToEnvVarName(rawSecret.Key)
 
 		envVarKeys = append(envVarKeys, envVarKey)
 
@@ -109,37 +105,23 @@ func (e *Environ) load(s store.Store, service string, collisions *[]string, noPa
 // Load loads environment variables into e from s given a service
 // collisions will be populated with any keys that get overwritten
 func (e *Environ) Load(s store.Store, service string, collisions *[]string) error {
-	return e.load(s, service, collisions, false)
-}
-
-// LoadNoPaths is identical to Load, but uses v1-style "."-separated paths
-//
-// Deprecated like all noPaths functionality
-func (e *Environ) LoadNoPaths(s store.Store, service string, collisions *[]string) error {
-	return e.load(s, service, collisions, true)
+	return e.load(s, service, collisions)
 }
 
 // LoadStrict loads all services from s in strict mode: env vars in e with value equal to valueExpected
 // are the only ones substituted. If there are any env vars in s that are also in e, but don't have their value
 // set to valueExpected, this is an error.
 func (e *Environ) LoadStrict(s store.Store, valueExpected string, pristine bool, services ...string) error {
-	return e.loadStrict(s, valueExpected, pristine, false, services...)
+	return e.loadStrict(s, valueExpected, pristine, services...)
 }
 
-// LoadNoPathsStrict is identical to LoadStrict, but uses v1-style "."-separated paths
-//
-// Deprecated like all noPaths functionality
-func (e *Environ) LoadStrictNoPaths(s store.Store, valueExpected string, pristine bool, services ...string) error {
-	return e.loadStrict(s, valueExpected, pristine, true, services...)
-}
-
-func (e *Environ) loadStrict(s store.Store, valueExpected string, pristine bool, noPaths bool, services ...string) error {
+func (e *Environ) loadStrict(s store.Store, valueExpected string, pristine bool, services ...string) error {
 	for _, service := range services {
 		rawSecrets, err := s.ListRaw(utils.NormalizeService(service))
 		if err != nil {
 			return err
 		}
-		err = e.loadStrictOne(rawSecrets, valueExpected, pristine, noPaths)
+		err = e.loadStrictOne(rawSecrets, valueExpected, pristine)
 		if err != nil {
 			return err
 		}
@@ -147,7 +129,7 @@ func (e *Environ) loadStrict(s store.Store, valueExpected string, pristine bool,
 	return nil
 }
 
-func (e *Environ) loadStrictOne(rawSecrets []store.RawSecret, valueExpected string, pristine bool, noPaths bool) error {
+func (e *Environ) loadStrictOne(rawSecrets []store.RawSecret, valueExpected string, pristine bool) error {
 	parentMap := e.Map()
 	parentExpects := map[string]struct{}{}
 	for k, v := range parentMap {
@@ -162,7 +144,7 @@ func (e *Environ) loadStrictOne(rawSecrets []store.RawSecret, valueExpected stri
 
 	envVarKeysAdded := map[string]struct{}{}
 	for _, rawSecret := range rawSecrets {
-		envVarKey := secretKeyToEnvVarName(rawSecret.Key, noPaths)
+		envVarKey := secretKeyToEnvVarName(rawSecret.Key)
 
 		parentVal, parentOk := parentMap[envVarKey]
 		// skip injecting secrets that are not present in the parent

--- a/environ/environ_test.go
+++ b/environ/environ_test.go
@@ -99,7 +99,7 @@ func TestEnvironStrict(t *testing.T) {
 			if strictVal == "" {
 				strictVal = "chamberme"
 			}
-			err := tc.e.loadStrictOne(rawSecrets, strictVal, tc.pristine, false)
+			err := tc.e.loadStrictOne(rawSecrets, strictVal, tc.pristine)
 			if err != nil {
 				assert.EqualValues(t, tc.expectedErr, err)
 			} else {


### PR DESCRIPTION
Version 2.0 of chamber deprecated use of the non-path-based API for the
SSM parameter store. This commit removes support for it completely.

Since the deprecation occurred so long ago, this changeset does not
preserve the ability to migrate to using the path-based API. Migration
may be performed with a 2.x version of chamber prior to upgrading to
a 3.x version.

BREAKING CHANGE: Any users or clients still using the non-path-based SSM API will see errors working with the SSM parameter store.
