### PR TITLE
chore: Add golangci-lint and fix most issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,24 @@ ANALYTICS_WRITE_KEY ?=
 LDFLAGS := -ldflags='-X "main.Version=$(VERSION)" -X "main.AnalyticsWriteKey=$(ANALYTICS_WRITE_KEY)"'
 MOQ := $(shell command -v moq 2> /dev/null)
 SRC := $(shell find . -name '*.go')
+GOLANGCI_LINT := $(shell command -v golangci-lint 2> /dev/null)
+
+vet:
+	go vet ./...
 
 test: store/awsapi_mock.go
 	go test -v ./...
 
-.PHONY: coverage
 coverage:
 	go test -coverpkg ./... -coverprofile coverage.out ./...
+
+lint: vet
+ifdef GOLANGCI_LINT
+	@golangci-lint run --max-same-issues 0 --max-issues-per-linter 0
+else
+	@echo "Please install golangci-lint: brew install golangci-lint"
+	@false
+endif
 
 store/awsapi_mock.go: store/awsapi.go
 ifdef MOQ
@@ -71,4 +82,4 @@ dist/chamber-$(VERSION)-linux-arm64 dist/chamber-$(VERSION)-linux-aarch64: | dis
 dist/chamber-$(VERSION)-windows-amd64.exe: | dist/
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -trimpath $(LDFLAGS) -o $@
 
-.PHONY: clean all fmt build linux
+.PHONY: vet test coverage lint clean all fmt build linux

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -40,7 +40,7 @@ func delete(cmd *cobra.Command, args []string) error {
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -75,7 +75,7 @@ func exportEnv(cmd *cobra.Command, args []string) ([]string, error) {
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -35,7 +34,7 @@ func Test_sanitizeKey(t *testing.T) {
 	}{
 		{given: "invalid strings", expected: "invalid_strings"},
 		{given: "extremely  invalid  strings", expected: "extremely__invalid__strings"},
-		{given: fmt.Sprintf("\nunbelievably\tinvalid\tstrings\n"), expected: "unbelievably_invalid_strings"},
+		{given: "\nunbelievably\tinvalid\tstrings\n", expected: "unbelievably_invalid_strings"},
 		{given: "valid_string", expected: "valid_string"},
 		{given: "validish-string", expected: "validish_string"},
 		{given: "valid.string", expected: "valid_string"},

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -75,7 +75,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	services, command, commandArgs := args[:dashIx], args[dashIx], args[dashIx+1:]
 
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().
@@ -118,9 +118,8 @@ func execRun(cmd *cobra.Command, args []string) error {
 		}
 		for _, service := range services {
 			collisions := make([]string, 0)
-			var err error
 			// TODO: these interfaces should look the same as Strict*, so move pristine in there
-			err = env.Load(cmd.Context(), secretStore, service, &collisions)
+			err := env.Load(cmd.Context(), secretStore, service, &collisions)
 			if err != nil {
 				return fmt.Errorf("Failed to list store contents: %w", err)
 			}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -42,7 +42,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 	var err error
 
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().
@@ -82,6 +82,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 		if file, err = os.OpenFile(exportOutput, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644); err != nil {
 			return fmt.Errorf("Failed to open output file for writing: %w", err)
 		}
+		// TODO: check for errors flushing, syncing, or closing
 		defer file.Close()
 		defer file.Sync()
 	}
@@ -144,7 +145,10 @@ func exportAsTFvars(params map[string]string, w io.Writer) error {
 	for _, k := range sortedKeys(params) {
 		key := sanitizeKey(strings.TrimPrefix(k, "tf_var_"))
 
-		w.Write([]byte(fmt.Sprintf(`%s = "%s"`+"\n", key, doubleQuoteEscape(params[k]))))
+		_, err := w.Write([]byte(fmt.Sprintf(`%s = "%s"`+"\n", key, doubleQuoteEscape(params[k]))))
+		if err != nil {
+			return fmt.Errorf("failed to write variable with key %s: %v", k, err)
+		}
 	}
 	return nil
 }
@@ -170,7 +174,10 @@ func exportAsJavaProperties(params map[string]string, w io.Writer) error {
 	p := properties.NewProperties()
 	p.DisableExpansion = true
 	for _, k := range sortedKeys(params) {
-		p.Set(k, params[k])
+		_, _, err := p.Set(k, params[k])
+		if err != nil {
+			return fmt.Errorf("failed to set property %s: %v", k, err)
+		}
 	}
 
 	// Java expects properties in ISO-8859-1 by default

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -35,7 +35,7 @@ func history(cmd *cobra.Command, args []string) error {
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -54,7 +54,7 @@ func importRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -43,7 +43,7 @@ func list(cmd *cobra.Command, args []string) error {
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -42,7 +42,7 @@ func read(cmd *cobra.Command, args []string) error {
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,7 +105,7 @@ func Execute(vers string, writeKey string) {
 
 	if cmd, err := RootCmd.ExecuteC(); err != nil {
 		if strings.Contains(err.Error(), "arg(s)") || strings.Contains(err.Error(), "usage") {
-			cmd.Usage()
+			_ = cmd.Usage()
 		}
 		os.Exit(1)
 	}
@@ -206,7 +206,8 @@ func getSecretStore(ctx context.Context) (store.Store, error) {
 			return nil, errors.New("Unable to use --kms-key-alias with this backend. Use CHAMBER_KMS_KEY_ALIAS instead.")
 		}
 
-		parsedRetryMode, err := aws.ParseRetryMode(retryMode)
+		var parsedRetryMode aws.RetryMode
+		parsedRetryMode, err = aws.ParseRetryMode(retryMode)
 		if err != nil {
 			return nil, fmt.Errorf("Invalid retry mode %s", retryMode)
 		}
@@ -225,7 +226,7 @@ func prerun(cmd *cobra.Command, args []string) {
 		})
 
 		username = os.Getenv("USER")
-		analyticsClient.Enqueue(analytics.Identify{
+		_ = analyticsClient.Enqueue(analytics.Identify{
 			UserId: username,
 			Traits: analytics.NewTraits().
 				Set("chamber-version", chamberVersion),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,7 +22,7 @@ func init() {
 func versionRun(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "chamber %s\n", chamberVersion)
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -44,7 +44,7 @@ func write(cmd *cobra.Command, args []string) error {
 	}
 
 	if analyticsEnabled && analyticsClient != nil {
-		analyticsClient.Enqueue(analytics.Track{
+		_ = analyticsClient.Enqueue(analytics.Track{
 			UserId: username,
 			Event:  "Ran Command",
 			Properties: analytics.NewProperties().
@@ -67,7 +67,7 @@ func write(cmd *cobra.Command, args []string) error {
 			}
 			value = strings.TrimSuffix(v, "\n")
 		} else {
-			v, err := ioutil.ReadAll(os.Stdin)
+			v, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return err
 			}

--- a/environ/environ.go
+++ b/environ/environ.go
@@ -89,11 +89,8 @@ func (e *Environ) load(ctx context.Context, s store.Store, service string, colli
 	if err != nil {
 		return err
 	}
-	envVarKeys := make([]string, 0)
 	for _, rawSecret := range rawSecrets {
 		envVarKey := secretKeyToEnvVarName(rawSecret.Key)
-
-		envVarKeys = append(envVarKeys, envVarKey)
 
 		if e.IsSet(envVarKey) {
 			*collisions = append(*collisions, envVarKey)

--- a/store/backendbenchmarks_test.go
+++ b/store/backendbenchmarks_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // This file contains some tests which can be used to benchmark
@@ -49,11 +51,13 @@ func benchmarkStore(t *testing.T, store Store, services []string) {
 
 		for i := 0; i < concurrency; i++ {
 			wg.Add(1)
-			go emulateExec(t, ctx, &wg, store, services)
-
+			go func() {
+				// TODO: collect errors in a channel
+				_ = emulateExec(t, ctx, &wg, store, services)
+			}()
 		}
 		wg.Wait()
-		elapsed := time.Now().Sub(start)
+		elapsed := time.Since(start)
 		t.Logf("Concurrently started %d services in %s", concurrency, elapsed)
 	}
 }
@@ -106,7 +110,7 @@ func setupStore(t *testing.T, ctx context.Context, store Store, services []strin
 				Key:     key,
 			}
 
-			store.Write(ctx, id, RandStringRunes(100))
+			require.NoError(t, store.Write(ctx, id, RandStringRunes(100)))
 		}
 	}
 }
@@ -120,7 +124,7 @@ func cleanupStore(t *testing.T, ctx context.Context, store Store, services []str
 				Key:     key,
 			}
 
-			store.Delete(ctx, id)
+			require.NoError(t, store.Delete(ctx, id))
 		}
 	}
 }

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sort"
 	"time"
 
@@ -258,9 +258,7 @@ func (s *S3Store) Delete(ctx context.Context, id SecretId) error {
 		return err
 	}
 
-	if _, ok := index.Latest[id.Key]; ok {
-		delete(index.Latest, id.Key)
-	}
+	delete(index.Latest, id.Key)
 
 	if err := s.deleteObjectById(ctx, id); err != nil {
 		return err
@@ -317,7 +315,7 @@ func (s *S3Store) readObject(ctx context.Context, path string) (secretObject, bo
 		return secretObject{}, false, err
 	}
 
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return secretObject{}, false, err
 	}
@@ -366,7 +364,7 @@ func (s *S3Store) readLatest(ctx context.Context, service string) (latest, error
 		return latest{}, err
 	}
 
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return latest{}, err
 	}
@@ -388,15 +386,6 @@ func (s *S3Store) writeLatest(ctx context.Context, service string, index latest)
 	}
 
 	return s.puts3raw(ctx, path, raw)
-}
-
-func stringInSlice(val string, sl []string) bool {
-	for _, v := range sl {
-		if v == val {
-			return true
-		}
-	}
-	return false
 }
 
 func getObjectPath(id SecretId) string {

--- a/store/secretsmanagerstore.go
+++ b/store/secretsmanagerstore.go
@@ -136,9 +136,7 @@ func (s *SecretsManagerStore) Write(ctx context.Context, id SecretId, value stri
 		if err != nil {
 			return err
 		}
-		if _, ok := metadata[id.Key]; ok {
-			delete(metadata, id.Key)
-		}
+		delete(metadata, id.Key)
 
 		rawMetadata, err := dehydrateMetadata(&metadata)
 		if err != nil {

--- a/store/shared_test.go
+++ b/store/shared_test.go
@@ -32,6 +32,7 @@ func TestGetConfig(t *testing.T) {
 	assert.Equal(t, "us-west-2", region)
 
 	endpoint, err := config.EndpointResolverWithOptions.ResolveEndpoint("ssm", "us-west-2")
+	assert.NoError(t, err)
 	assert.Equal(t, "https://example.com/custom-endpoint", endpoint.URL)
 	assert.Equal(t, aws.EndpointSourceCustom, endpoint.Source)
 

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -26,10 +26,6 @@ const (
 // when using paths
 var validPathKeyFormat = regexp.MustCompile(`^(\/[\w\-\.]+)+$`)
 
-// validKeyFormat is the format that is expected for key names inside parameter store when
-// not using paths
-var validKeyFormat = regexp.MustCompile(`^[\w\-\.]+$`)
-
 // ensure SSMStore confirms to Store interface
 var _ Store = &SSMStore{}
 
@@ -206,14 +202,13 @@ func (s *SSMStore) readLatest(ctx context.Context, id SecretId) (Secret, error) 
 	}
 	param := resp.Parameters[0]
 	var parameter *types.ParameterMetadata
-	var describeParametersInput *ssm.DescribeParametersInput
 
 	// To get metadata, we need to use describe parameters
 
 	// There is no way to use describe parameters to get a single key
 	// if that key uses paths, so instead get all the keys for a path,
 	// then find the one you are looking for :(
-	describeParametersInput = &ssm.DescribeParametersInput{
+	describeParametersInput := &ssm.DescribeParametersInput{
 		ParameterFilters: []types.ParameterStringFilter{
 			{
 				Key:    aws.String("Path"),
@@ -250,9 +245,8 @@ func (s *SSMStore) readLatest(ctx context.Context, id SecretId) (Secret, error) 
 
 func (s *SSMStore) ListServices(ctx context.Context, service string, includeSecretName bool) ([]string, error) {
 	secrets := map[string]Secret{}
-	var describeParametersInput *ssm.DescribeParametersInput
 
-	describeParametersInput = &ssm.DescribeParametersInput{
+	describeParametersInput := &ssm.DescribeParametersInput{
 		MaxResults: aws.Int32(50),
 		ParameterFilters: []types.ParameterStringFilter{
 			{

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockParameter struct {
@@ -356,7 +357,7 @@ func TestListRawWithPaths(t *testing.T) {
 		{Service: "test", Key: "c"},
 	}
 	for _, secret := range secrets {
-		store.Write(ctx, secret, "value")
+		require.NoError(t, store.Write(ctx, secret, "value"))
 	}
 
 	t.Run("ListRaw should return all keys and values for a service", func(t *testing.T) {
@@ -374,8 +375,8 @@ func TestListRawWithPaths(t *testing.T) {
 	})
 
 	t.Run("List should only return exact matches on service name", func(t *testing.T) {
-		store.Write(ctx, SecretId{Service: "match", Key: "a"}, "val")
-		store.Write(ctx, SecretId{Service: "matchlonger", Key: "a"}, "val")
+		require.NoError(t, store.Write(ctx, SecretId{Service: "match", Key: "a"}, "val"))
+		require.NoError(t, store.Write(ctx, SecretId{Service: "matchlonger", Key: "a"}, "val"))
 
 		s, err := store.ListRaw(ctx, "match")
 		assert.Nil(t, err)
@@ -418,9 +419,9 @@ func TestReadPaths(t *testing.T) {
 	parameters := map[string]mockParameter{}
 	store := NewTestSSMStore(parameters)
 	secretId := SecretId{Service: "test", Key: "key"}
-	store.Write(ctx, secretId, "value")
-	store.Write(ctx, secretId, "second value")
-	store.Write(ctx, secretId, "third value")
+	require.NoError(t, store.Write(ctx, secretId, "value"))
+	require.NoError(t, store.Write(ctx, secretId, "second value"))
+	require.NoError(t, store.Write(ctx, secretId, "third value"))
 
 	t.Run("Reading the latest value should work", func(t *testing.T) {
 		s, err := store.Read(ctx, secretId, -1)
@@ -464,7 +465,7 @@ func TestListPaths(t *testing.T) {
 		{Service: "test", Key: "c"},
 	}
 	for _, secret := range secrets {
-		store.Write(ctx, secret, "value")
+		require.NoError(t, store.Write(ctx, secret, "value"))
 	}
 
 	t.Run("List should return all keys for a service", func(t *testing.T) {
@@ -494,8 +495,8 @@ func TestListPaths(t *testing.T) {
 	})
 
 	t.Run("List should only return exact matches on service name", func(t *testing.T) {
-		store.Write(ctx, SecretId{Service: "match", Key: "a"}, "val")
-		store.Write(ctx, SecretId{Service: "matchlonger", Key: "a"}, "val")
+		require.NoError(t, store.Write(ctx, SecretId{Service: "match", Key: "a"}, "val"))
+		require.NoError(t, store.Write(ctx, SecretId{Service: "matchlonger", Key: "a"}, "val"))
 
 		s, err := store.List(ctx, "match", false)
 		assert.Nil(t, err)
@@ -517,7 +518,7 @@ func TestHistoryPaths(t *testing.T) {
 	}
 
 	for _, s := range secrets {
-		store.Write(ctx, s, "value")
+		require.NoError(t, store.Write(ctx, s, "value"))
 	}
 
 	t.Run("History for a non-existent key should return not found error", func(t *testing.T) {
@@ -548,7 +549,7 @@ func TestDeletePaths(t *testing.T) {
 	store := NewTestSSMStore(parameters)
 
 	secretId := SecretId{Service: "test", Key: "key"}
-	store.Write(ctx, secretId, "value")
+	require.NoError(t, store.Write(ctx, secretId, "value"))
 
 	t.Run("Deleting secret should work", func(t *testing.T) {
 		err := store.Delete(ctx, secretId)


### PR DESCRIPTION
The new `make lint` target runs golangci-lint if installed locally. It
is not (yet) required for a passing build.

Most issues reported by golangci-lint are resolved. Some interesting
ones:

* Missing error checking is added for exporting to a properties file and
  to Terraform variables.
* Unused functions are removed: stringInSlice, S3KMSStore.readObject.
* Unused variables are removed: validKeyFormat.
* Write operations used to set up store tests now have their errors
  checked. If a setup write fails, the test immediately fails.

Unresolved issues:

* Use of EndpointResolverWithOptions
* Missing error checks for flushing, syncing, and closing a file
  created by the export command
