### PR TITLE
feat: Add tag read, write, and delete commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,8 @@ var (
 	validKeyFormat                  = regexp.MustCompile(`^[\w\-\.]+$`)
 	validServicePathFormat          = regexp.MustCompile(`^[\w\-\.]+(\/[\w\-\.]+)*$`)
 	validServicePathFormatWithLabel = regexp.MustCompile(`^[\w\-\.]+((\/[\w\-\.]+)+(\:[\w\-\.]+)*)?$`)
+	validTagKeyFormat               = regexp.MustCompile(`^[A-Za-z0-9 +\-=\._:/@]{1,128}$`)
+	validTagValueFormat             = regexp.MustCompile(`^[A-Za-z0-9 +\-=\._:/@]{1,256}$`)
 
 	verbose    bool
 	numRetries int
@@ -130,6 +132,16 @@ func validateServiceWithLabel(service string) error {
 func validateKey(key string) error {
 	if !validKeyFormat.MatchString(key) {
 		return fmt.Errorf("Failed to validate key name '%s'. Only alphanumeric, dashes, full stops and underscores are allowed for key names", key)
+	}
+	return nil
+}
+
+func validateTag(key string, value string) error {
+	if !validTagKeyFormat.MatchString(key) {
+		return fmt.Errorf("Failed to validate tag key '%s'. Only 128 alphanumeric, space, and characters +-=._:/@ are allowed for tag keys", key)
+	}
+	if !validTagValueFormat.MatchString(value) {
+		return fmt.Errorf("Failed to validate tag value '%s'. Only 256 alphanumeric, space, and characters +-=._:/@ are allowed for tag values", value)
 	}
 	return nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidations(t *testing.T) {
-
-	// Test Key formats
+func TestValidateKey(t *testing.T) {
 	validKeyFormat := []string{
 		"foo",
 		"foo.bar",
@@ -23,7 +21,9 @@ func TestValidations(t *testing.T) {
 			assert.Nil(t, result)
 		})
 	}
+}
 
+func TestValidateKey_Invalid(t *testing.T) {
 	invalidKeyFormat := []string{
 		"/foo",
 		"foo//bar",
@@ -36,8 +36,9 @@ func TestValidations(t *testing.T) {
 			assert.Error(t, result)
 		})
 	}
+}
 
-	// Test Service format with PATH
+func TestValidateService_Path(t *testing.T) {
 	validServicePathFormat := []string{
 		"foo",
 		"foo.",
@@ -58,7 +59,9 @@ func TestValidations(t *testing.T) {
 			assert.Nil(t, result)
 		})
 	}
+}
 
+func TestValidateService_Path_Invalid(t *testing.T) {
 	invalidServicePathFormat := []string{
 		"foo/",
 		"/foo",
@@ -71,8 +74,9 @@ func TestValidations(t *testing.T) {
 			assert.Error(t, result)
 		})
 	}
+}
 
-	// Test Service format with PATH and Label
+func TestValidateService_PathLabel(t *testing.T) {
 	validServicePathFormatWithLabel := []string{
 		"foo",
 		"foo/bar:-current-",
@@ -90,7 +94,9 @@ func TestValidations(t *testing.T) {
 			assert.Nil(t, result)
 		})
 	}
+}
 
+func TestValidateService_PathLabel_Invalid(t *testing.T) {
 	invalidServicePathFormatWithLabel := []string{
 		"foo:current$",
 		"foo.:",

--- a/cmd/tag-delete.go
+++ b/cmd/tag-delete.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+
+	analytics "github.com/segmentio/analytics-go/v3"
+	"github.com/segmentio/chamber/v2/store"
+	"github.com/segmentio/chamber/v2/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// tagWriteCmd represents the tag read command
+	tagDeleteCmd = &cobra.Command{
+		Use:   "delete <service> <key> <tag key>...",
+		Short: "Delete tags for a specific secret",
+		Args:  cobra.MinimumNArgs(3),
+		RunE:  tagDelete,
+	}
+)
+
+func init() {
+	tagCmd.AddCommand(tagDeleteCmd)
+}
+
+func tagDelete(cmd *cobra.Command, args []string) error {
+	service := utils.NormalizeService(args[0])
+	if err := validateService(service); err != nil {
+		return fmt.Errorf("Failed to validate service: %w", err)
+	}
+
+	key := utils.NormalizeKey(args[1])
+	if err := validateKey(key); err != nil {
+		return fmt.Errorf("Failed to validate key: %w", err)
+	}
+
+	tagKeys := make([]string, len(args)-2)
+	for i, tagArg := range args[2:] {
+		if err := validateTag(tagArg, "dummy"); err != nil {
+			return fmt.Errorf("Failed to validate tag key %s: %w", tagArg, err)
+		}
+		tagKeys[i] = tagArg
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		_ = analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "tag delete").
+				Set("chamber-version", chamberVersion).
+				Set("service", service).
+				Set("key", key).
+				Set("backend", backend),
+		})
+	}
+
+	secretStore, err := getSecretStore(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("Failed to get secret store: %w", err)
+	}
+
+	secretId := store.SecretId{
+		Service: service,
+		Key:     key,
+	}
+
+	err = secretStore.DeleteTags(cmd.Context(), secretId, tagKeys)
+	if err != nil {
+		return fmt.Errorf("Failed to delete tags: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/tag-read.go
+++ b/cmd/tag-read.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	analytics "github.com/segmentio/analytics-go/v3"
+	"github.com/segmentio/chamber/v2/store"
+	"github.com/segmentio/chamber/v2/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// tagReadCmd represents the tag read command
+	tagReadCmd = &cobra.Command{
+		Use:   "read <service> <key>",
+		Short: "Read tags for a specific secret",
+		Args:  cobra.ExactArgs(2),
+		RunE:  tagRead,
+	}
+)
+
+func init() {
+	tagCmd.AddCommand(tagReadCmd)
+}
+
+func tagRead(cmd *cobra.Command, args []string) error {
+	service := utils.NormalizeService(args[0])
+	if err := validateService(service); err != nil {
+		return fmt.Errorf("Failed to validate service: %w", err)
+	}
+
+	key := utils.NormalizeKey(args[1])
+	if err := validateKey(key); err != nil {
+		return fmt.Errorf("Failed to validate key: %w", err)
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		_ = analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "tag read").
+				Set("chamber-version", chamberVersion).
+				Set("service", service).
+				Set("key", key).
+				Set("backend", backend),
+		})
+	}
+
+	secretStore, err := getSecretStore(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("Failed to get secret store: %w", err)
+	}
+
+	secretId := store.SecretId{
+		Service: service,
+		Key:     key,
+	}
+
+	tags, err := secretStore.ReadTags(cmd.Context(), secretId)
+	if err != nil {
+		return fmt.Errorf("Failed to read tags: %w", err)
+	}
+
+	if quiet {
+		fmt.Fprintf(os.Stdout, "%s\n", tags)
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)
+	fmt.Fprintln(w, "Key\tValue")
+	for k, v := range tags {
+		fmt.Fprintf(w, "%s\t%s\n", k, v)
+	}
+	w.Flush()
+	return nil
+}

--- a/cmd/tag-write.go
+++ b/cmd/tag-write.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	analytics "github.com/segmentio/analytics-go/v3"
+	"github.com/segmentio/chamber/v2/store"
+	"github.com/segmentio/chamber/v2/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	deleteOtherTags bool
+
+	// tagWriteCmd represents the tag read command
+	tagWriteCmd = &cobra.Command{
+		Use:   "write <service> <key> <tag>...",
+		Short: "Write tags for a specific secret",
+		Args:  cobra.MinimumNArgs(3),
+		RunE:  tagWrite,
+	}
+)
+
+func init() {
+	tagWriteCmd.Flags().BoolVar(&deleteOtherTags, "delete-other-tags", false, "Delete tags not specified in the command")
+	tagCmd.AddCommand(tagWriteCmd)
+}
+
+func tagWrite(cmd *cobra.Command, args []string) error {
+	service := utils.NormalizeService(args[0])
+	if err := validateService(service); err != nil {
+		return fmt.Errorf("Failed to validate service: %w", err)
+	}
+
+	key := utils.NormalizeKey(args[1])
+	if err := validateKey(key); err != nil {
+		return fmt.Errorf("Failed to validate key: %w", err)
+	}
+
+	tags := make(map[string]string, len(args)-2)
+	for _, tagArg := range args[2:] {
+		tagKey, tagValue, found := strings.Cut(tagArg, "=")
+		if !found {
+			return fmt.Errorf("Failed to parse tag %s: tag must be in the form key=value", tagArg)
+		}
+		if err := validateTag(tagKey, tagValue); err != nil {
+			return fmt.Errorf("Failed to validate tag with key %s: %w", tagKey, err)
+		}
+		tags[tagKey] = tagValue
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		_ = analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("command", "tag write").
+				Set("chamber-version", chamberVersion).
+				Set("service", service).
+				Set("key", key).
+				Set("backend", backend),
+		})
+	}
+
+	secretStore, err := getSecretStore(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("Failed to get secret store: %w", err)
+	}
+
+	secretId := store.SecretId{
+		Service: service,
+		Key:     key,
+	}
+
+	err = secretStore.WriteTags(cmd.Context(), secretId, tags, deleteOtherTags)
+	if err != nil {
+		return fmt.Errorf("Failed to write tags: %w", err)
+	}
+
+	if quiet {
+		fmt.Fprintf(os.Stdout, "%s\n", tags)
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)
+	fmt.Fprintln(w, "Key\tValue")
+	for k, v := range tags {
+		fmt.Fprintf(w, "%s\t%s\n", k, v)
+	}
+	w.Flush()
+	return nil
+}

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	// tagCmd represents the tag command
+	tagCmd = &cobra.Command{
+		Use:   "tag <subcommand> ...",
+		Short: "work with tags on secrets",
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(tagCmd)
+}

--- a/store/awsapi.go
+++ b/store/awsapi.go
@@ -26,12 +26,15 @@ type apiS3 interface {
 }
 
 type apiSSM interface {
+	AddTagsToResource(ctx context.Context, params *ssm.AddTagsToResourceInput, optFns ...func(*ssm.Options)) (*ssm.AddTagsToResourceOutput, error)
 	DeleteParameter(ctx context.Context, params *ssm.DeleteParameterInput, optFns ...func(*ssm.Options)) (*ssm.DeleteParameterOutput, error)
 	DescribeParameters(ctx context.Context, params *ssm.DescribeParametersInput, optFns ...func(*ssm.Options)) (*ssm.DescribeParametersOutput, error)
 	GetParameterHistory(ctx context.Context, params *ssm.GetParameterHistoryInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterHistoryOutput, error)
 	GetParameters(ctx context.Context, params *ssm.GetParametersInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersOutput, error)
 	GetParametersByPath(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error)
+	ListTagsForResource(ctx context.Context, params *ssm.ListTagsForResourceInput, optFns ...func(*ssm.Options)) (*ssm.ListTagsForResourceOutput, error)
 	PutParameter(ctx context.Context, params *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error)
+	RemoveTagsFromResource(ctx context.Context, params *ssm.RemoveTagsFromResourceInput, optFns ...func(*ssm.Options)) (*ssm.RemoveTagsFromResourceOutput, error)
 }
 
 type apiSTS interface {

--- a/store/awsapi_mock.go
+++ b/store/awsapi_mock.go
@@ -268,6 +268,9 @@ var _ apiSSM = &apiSSMMock{}
 //
 //		// make and configure a mocked apiSSM
 //		mockedapiSSM := &apiSSMMock{
+//			AddTagsToResourceFunc: func(ctx context.Context, params *ssm.AddTagsToResourceInput, optFns ...func(*ssm.Options)) (*ssm.AddTagsToResourceOutput, error) {
+//				panic("mock out the AddTagsToResource method")
+//			},
 //			DeleteParameterFunc: func(ctx context.Context, params *ssm.DeleteParameterInput, optFns ...func(*ssm.Options)) (*ssm.DeleteParameterOutput, error) {
 //				panic("mock out the DeleteParameter method")
 //			},
@@ -283,8 +286,14 @@ var _ apiSSM = &apiSSMMock{}
 //			GetParametersByPathFunc: func(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error) {
 //				panic("mock out the GetParametersByPath method")
 //			},
+//			ListTagsForResourceFunc: func(ctx context.Context, params *ssm.ListTagsForResourceInput, optFns ...func(*ssm.Options)) (*ssm.ListTagsForResourceOutput, error) {
+//				panic("mock out the ListTagsForResource method")
+//			},
 //			PutParameterFunc: func(ctx context.Context, params *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error) {
 //				panic("mock out the PutParameter method")
+//			},
+//			RemoveTagsFromResourceFunc: func(ctx context.Context, params *ssm.RemoveTagsFromResourceInput, optFns ...func(*ssm.Options)) (*ssm.RemoveTagsFromResourceOutput, error) {
+//				panic("mock out the RemoveTagsFromResource method")
 //			},
 //		}
 //
@@ -293,6 +302,9 @@ var _ apiSSM = &apiSSMMock{}
 //
 //	}
 type apiSSMMock struct {
+	// AddTagsToResourceFunc mocks the AddTagsToResource method.
+	AddTagsToResourceFunc func(ctx context.Context, params *ssm.AddTagsToResourceInput, optFns ...func(*ssm.Options)) (*ssm.AddTagsToResourceOutput, error)
+
 	// DeleteParameterFunc mocks the DeleteParameter method.
 	DeleteParameterFunc func(ctx context.Context, params *ssm.DeleteParameterInput, optFns ...func(*ssm.Options)) (*ssm.DeleteParameterOutput, error)
 
@@ -308,11 +320,26 @@ type apiSSMMock struct {
 	// GetParametersByPathFunc mocks the GetParametersByPath method.
 	GetParametersByPathFunc func(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error)
 
+	// ListTagsForResourceFunc mocks the ListTagsForResource method.
+	ListTagsForResourceFunc func(ctx context.Context, params *ssm.ListTagsForResourceInput, optFns ...func(*ssm.Options)) (*ssm.ListTagsForResourceOutput, error)
+
 	// PutParameterFunc mocks the PutParameter method.
 	PutParameterFunc func(ctx context.Context, params *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error)
 
+	// RemoveTagsFromResourceFunc mocks the RemoveTagsFromResource method.
+	RemoveTagsFromResourceFunc func(ctx context.Context, params *ssm.RemoveTagsFromResourceInput, optFns ...func(*ssm.Options)) (*ssm.RemoveTagsFromResourceOutput, error)
+
 	// calls tracks calls to the methods.
 	calls struct {
+		// AddTagsToResource holds details about calls to the AddTagsToResource method.
+		AddTagsToResource []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Params is the params argument value.
+			Params *ssm.AddTagsToResourceInput
+			// OptFns is the optFns argument value.
+			OptFns []func(*ssm.Options)
+		}
 		// DeleteParameter holds details about calls to the DeleteParameter method.
 		DeleteParameter []struct {
 			// Ctx is the ctx argument value.
@@ -358,6 +385,15 @@ type apiSSMMock struct {
 			// OptFns is the optFns argument value.
 			OptFns []func(*ssm.Options)
 		}
+		// ListTagsForResource holds details about calls to the ListTagsForResource method.
+		ListTagsForResource []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Params is the params argument value.
+			Params *ssm.ListTagsForResourceInput
+			// OptFns is the optFns argument value.
+			OptFns []func(*ssm.Options)
+		}
 		// PutParameter holds details about calls to the PutParameter method.
 		PutParameter []struct {
 			// Ctx is the ctx argument value.
@@ -367,13 +403,65 @@ type apiSSMMock struct {
 			// OptFns is the optFns argument value.
 			OptFns []func(*ssm.Options)
 		}
+		// RemoveTagsFromResource holds details about calls to the RemoveTagsFromResource method.
+		RemoveTagsFromResource []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Params is the params argument value.
+			Params *ssm.RemoveTagsFromResourceInput
+			// OptFns is the optFns argument value.
+			OptFns []func(*ssm.Options)
+		}
 	}
-	lockDeleteParameter     sync.RWMutex
-	lockDescribeParameters  sync.RWMutex
-	lockGetParameterHistory sync.RWMutex
-	lockGetParameters       sync.RWMutex
-	lockGetParametersByPath sync.RWMutex
-	lockPutParameter        sync.RWMutex
+	lockAddTagsToResource      sync.RWMutex
+	lockDeleteParameter        sync.RWMutex
+	lockDescribeParameters     sync.RWMutex
+	lockGetParameterHistory    sync.RWMutex
+	lockGetParameters          sync.RWMutex
+	lockGetParametersByPath    sync.RWMutex
+	lockListTagsForResource    sync.RWMutex
+	lockPutParameter           sync.RWMutex
+	lockRemoveTagsFromResource sync.RWMutex
+}
+
+// AddTagsToResource calls AddTagsToResourceFunc.
+func (mock *apiSSMMock) AddTagsToResource(ctx context.Context, params *ssm.AddTagsToResourceInput, optFns ...func(*ssm.Options)) (*ssm.AddTagsToResourceOutput, error) {
+	if mock.AddTagsToResourceFunc == nil {
+		panic("apiSSMMock.AddTagsToResourceFunc: method is nil but apiSSM.AddTagsToResource was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		Params *ssm.AddTagsToResourceInput
+		OptFns []func(*ssm.Options)
+	}{
+		Ctx:    ctx,
+		Params: params,
+		OptFns: optFns,
+	}
+	mock.lockAddTagsToResource.Lock()
+	mock.calls.AddTagsToResource = append(mock.calls.AddTagsToResource, callInfo)
+	mock.lockAddTagsToResource.Unlock()
+	return mock.AddTagsToResourceFunc(ctx, params, optFns...)
+}
+
+// AddTagsToResourceCalls gets all the calls that were made to AddTagsToResource.
+// Check the length with:
+//
+//	len(mockedapiSSM.AddTagsToResourceCalls())
+func (mock *apiSSMMock) AddTagsToResourceCalls() []struct {
+	Ctx    context.Context
+	Params *ssm.AddTagsToResourceInput
+	OptFns []func(*ssm.Options)
+} {
+	var calls []struct {
+		Ctx    context.Context
+		Params *ssm.AddTagsToResourceInput
+		OptFns []func(*ssm.Options)
+	}
+	mock.lockAddTagsToResource.RLock()
+	calls = mock.calls.AddTagsToResource
+	mock.lockAddTagsToResource.RUnlock()
+	return calls
 }
 
 // DeleteParameter calls DeleteParameterFunc.
@@ -576,6 +664,46 @@ func (mock *apiSSMMock) GetParametersByPathCalls() []struct {
 	return calls
 }
 
+// ListTagsForResource calls ListTagsForResourceFunc.
+func (mock *apiSSMMock) ListTagsForResource(ctx context.Context, params *ssm.ListTagsForResourceInput, optFns ...func(*ssm.Options)) (*ssm.ListTagsForResourceOutput, error) {
+	if mock.ListTagsForResourceFunc == nil {
+		panic("apiSSMMock.ListTagsForResourceFunc: method is nil but apiSSM.ListTagsForResource was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		Params *ssm.ListTagsForResourceInput
+		OptFns []func(*ssm.Options)
+	}{
+		Ctx:    ctx,
+		Params: params,
+		OptFns: optFns,
+	}
+	mock.lockListTagsForResource.Lock()
+	mock.calls.ListTagsForResource = append(mock.calls.ListTagsForResource, callInfo)
+	mock.lockListTagsForResource.Unlock()
+	return mock.ListTagsForResourceFunc(ctx, params, optFns...)
+}
+
+// ListTagsForResourceCalls gets all the calls that were made to ListTagsForResource.
+// Check the length with:
+//
+//	len(mockedapiSSM.ListTagsForResourceCalls())
+func (mock *apiSSMMock) ListTagsForResourceCalls() []struct {
+	Ctx    context.Context
+	Params *ssm.ListTagsForResourceInput
+	OptFns []func(*ssm.Options)
+} {
+	var calls []struct {
+		Ctx    context.Context
+		Params *ssm.ListTagsForResourceInput
+		OptFns []func(*ssm.Options)
+	}
+	mock.lockListTagsForResource.RLock()
+	calls = mock.calls.ListTagsForResource
+	mock.lockListTagsForResource.RUnlock()
+	return calls
+}
+
 // PutParameter calls PutParameterFunc.
 func (mock *apiSSMMock) PutParameter(ctx context.Context, params *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error) {
 	if mock.PutParameterFunc == nil {
@@ -613,6 +741,46 @@ func (mock *apiSSMMock) PutParameterCalls() []struct {
 	mock.lockPutParameter.RLock()
 	calls = mock.calls.PutParameter
 	mock.lockPutParameter.RUnlock()
+	return calls
+}
+
+// RemoveTagsFromResource calls RemoveTagsFromResourceFunc.
+func (mock *apiSSMMock) RemoveTagsFromResource(ctx context.Context, params *ssm.RemoveTagsFromResourceInput, optFns ...func(*ssm.Options)) (*ssm.RemoveTagsFromResourceOutput, error) {
+	if mock.RemoveTagsFromResourceFunc == nil {
+		panic("apiSSMMock.RemoveTagsFromResourceFunc: method is nil but apiSSM.RemoveTagsFromResource was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		Params *ssm.RemoveTagsFromResourceInput
+		OptFns []func(*ssm.Options)
+	}{
+		Ctx:    ctx,
+		Params: params,
+		OptFns: optFns,
+	}
+	mock.lockRemoveTagsFromResource.Lock()
+	mock.calls.RemoveTagsFromResource = append(mock.calls.RemoveTagsFromResource, callInfo)
+	mock.lockRemoveTagsFromResource.Unlock()
+	return mock.RemoveTagsFromResourceFunc(ctx, params, optFns...)
+}
+
+// RemoveTagsFromResourceCalls gets all the calls that were made to RemoveTagsFromResource.
+// Check the length with:
+//
+//	len(mockedapiSSM.RemoveTagsFromResourceCalls())
+func (mock *apiSSMMock) RemoveTagsFromResourceCalls() []struct {
+	Ctx    context.Context
+	Params *ssm.RemoveTagsFromResourceInput
+	OptFns []func(*ssm.Options)
+} {
+	var calls []struct {
+		Ctx    context.Context
+		Params *ssm.RemoveTagsFromResourceInput
+		OptFns []func(*ssm.Options)
+	}
+	mock.lockRemoveTagsFromResource.RLock()
+	calls = mock.calls.RemoveTagsFromResource
+	mock.lockRemoveTagsFromResource.RUnlock()
 	return calls
 }
 

--- a/store/nullstore.go
+++ b/store/nullstore.go
@@ -21,6 +21,14 @@ func (s *NullStore) Read(ctx context.Context, id SecretId, version int) (Secret,
 	return Secret{}, errors.New("Not implemented for Null Store")
 }
 
+func (s *NullStore) WriteTags(ctx context.Context, id SecretId, tags map[string]string, deleteOtherTags bool) error {
+	return errors.New("Not implemented for Null Store")
+}
+
+func (s *NullStore) ReadTags(ctx context.Context, id SecretId) (map[string]string, error) {
+	return nil, errors.New("Not implemented for Null Store")
+}
+
 func (s *NullStore) ListServices(ctx context.Context, service string, includeSecretNames bool) ([]string, error) {
 	return nil, nil
 }
@@ -38,5 +46,9 @@ func (s *NullStore) History(ctx context.Context, id SecretId) ([]ChangeEvent, er
 }
 
 func (s *NullStore) Delete(ctx context.Context, id SecretId) error {
+	return errors.New("Not implemented for Null Store")
+}
+
+func (s *NullStore) DeleteTags(ctx context.Context, id SecretId, tags []string) error {
 	return errors.New("Not implemented for Null Store")
 }

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -160,6 +160,14 @@ func (s *S3Store) Read(ctx context.Context, id SecretId, version int) (Secret, e
 	}, nil
 }
 
+func (s *S3Store) WriteTags(ctx context.Context, id SecretId, tags map[string]string, deleteOtherTags bool) error {
+	return errors.New("Not implemented for S3 Store")
+}
+
+func (s *S3Store) ReadTags(ctx context.Context, id SecretId) (map[string]string, error) {
+	return nil, errors.New("Not implemented for S3 Store")
+}
+
 func (s *S3Store) ListServices(ctx context.Context, service string, includeSecretName bool) ([]string, error) {
 	return nil, fmt.Errorf("S3 Backend is experimental and does not implement this command")
 }
@@ -265,6 +273,10 @@ func (s *S3Store) Delete(ctx context.Context, id SecretId) error {
 	}
 
 	return s.writeLatest(ctx, id.Service, index)
+}
+
+func (s *S3Store) DeleteTags(ctx context.Context, id SecretId, tagKeys []string) error {
+	return errors.New("Not implemented for S3 Store")
 }
 
 // getCurrentUser uses the STS API to get the current caller identity,

--- a/store/secretsmanagerstore.go
+++ b/store/secretsmanagerstore.go
@@ -254,6 +254,10 @@ func (s *SecretsManagerStore) Delete(ctx context.Context, id SecretId) error {
 	return s.Write(ctx, id, "")
 }
 
+func (s *SecretsManagerStore) DeleteTags(ctx context.Context, id SecretId, tagKeys []string) error {
+	return errors.New("Not implemented for Secrets Manager Store")
+}
+
 func (s *SecretsManagerStore) readVersion(ctx context.Context, id SecretId, version int) (Secret, error) {
 	listSecretVersionIdsInput := &secretsmanager.ListSecretVersionIdsInput{
 		SecretId:          aws.String(id.Service),
@@ -343,6 +347,14 @@ func (s *SecretsManagerStore) readLatest(ctx context.Context, service string) (s
 	}
 
 	return obj, nil
+}
+
+func (s *SecretsManagerStore) WriteTags(ctx context.Context, id SecretId, tags map[string]string, deleteOtherTags bool) error {
+	return errors.New("Not implemented for Secrets Manager Store")
+}
+
+func (s *SecretsManagerStore) ReadTags(ctx context.Context, id SecretId) (map[string]string, error) {
+	return nil, errors.New("Not implemented for Secrets Manager Store")
 }
 
 // ListServices (not implemented)

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -128,13 +128,13 @@ func (s *SSMStore) Read(ctx context.Context, id SecretId, version int) (Secret, 
 }
 
 func (s *SSMStore) WriteTags(ctx context.Context, id SecretId, tags map[string]string, deleteOtherTags bool) error {
-	// list the current tags
-	currentTags, err := s.ReadTags(ctx, id)
-	if err != nil {
-		return err
-	}
-
 	if deleteOtherTags {
+		// list the current tags
+		currentTags, err := s.ReadTags(ctx, id)
+		if err != nil {
+			return err
+		}
+
 		var tagKeysToRemove []string
 		for k := range currentTags {
 			if _, ok := tags[k]; !ok {
@@ -164,7 +164,7 @@ func (s *SSMStore) WriteTags(ctx context.Context, id SecretId, tags map[string]s
 		ResourceId:   aws.String(s.idToName(id)),
 		Tags:         addTags,
 	}
-	_, err = s.svc.AddTagsToResource(ctx, addTagsInput)
+	_, err := s.svc.AddTagsToResource(ctx, addTagsInput)
 	if err != nil {
 		return err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -62,9 +62,12 @@ type ChangeEvent struct {
 type Store interface {
 	Write(ctx context.Context, id SecretId, value string) error
 	Read(ctx context.Context, id SecretId, version int) (Secret, error)
+	WriteTags(ctx context.Context, id SecretId, tags map[string]string, deleteOtherTags bool) error
+	ReadTags(ctx context.Context, id SecretId) (map[string]string, error)
 	List(ctx context.Context, service string, includeValues bool) ([]Secret, error)
 	ListRaw(ctx context.Context, service string) ([]RawSecret, error)
 	ListServices(ctx context.Context, service string, includeSecretName bool) ([]string, error)
 	History(ctx context.Context, id SecretId) ([]ChangeEvent, error)
 	Delete(ctx context.Context, id SecretId) error
+	DeleteTags(ctx context.Context, id SecretId, tagKeys []string) error
 }


### PR DESCRIPTION
The new commands are for reading, writing, and deleting tags on the
underlying resources representing secrets.

For now, the commands are only implemented for SSM parameters.
