### PR TITLE
feat: Add tag-on-create

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,42 @@ Secret keys are normalized automatically. The `-` will be `_` and the letters wi
 be converted to upper case (for example a secret with key `secret_key` and
 `secret-key` will become `SECRET_KEY`).
 
+#### Tagging on Write
+
+```bash
+$ chamber write <service> <key> <value> --tags key1=value1,key2=value2
+```
+
+This operation will write a secret into the secret store with the specified tags.
+Tagging on write is only available for new secrets.
+
+### Tagging Secrets
+
+```bash
+$ chamber tag write <service> <key> tag1=value1 tag2=value2
+Key Value
+tag1  value1
+tag2  value2
+$ chamber tag read <service> <key>
+Key Value
+tag1  value1
+tag2  value2
+$ chamber tag delete <service> <key> tag1
+$ chamber tag read <service> <key>
+Key Value
+tag2  value2
+```
+
+Writing tags normally leaves other tags intact. If you want to replace all tags
+with the new ones, use `--delete-other-tags` flag. _Note: The option may change
+before the next major release._
+
+```bash
+$ chamber tag write --delete-other-tags <service> <key> tag1=value1
+Key Value
+tag1  value1
+```
+
 ### Listing Secrets
 
 ```bash

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -16,6 +16,7 @@ import (
 var (
 	singleline    bool
 	skipUnchanged bool
+	tags          map[string]string
 
 	// writeCmd represents the write command
 	writeCmd = &cobra.Command{
@@ -29,6 +30,7 @@ var (
 func init() {
 	writeCmd.Flags().BoolVarP(&singleline, "singleline", "s", false, "Insert single line parameter (end with \\n)")
 	writeCmd.Flags().BoolVarP(&skipUnchanged, "skip-unchanged", "", false, "Skip writing secret if value is unchanged")
+	writeCmd.Flags().StringToStringVarP(&tags, "tags", "t", map[string]string{}, "Add tags to the secret; new secrets only")
 	RootCmd.AddCommand(writeCmd)
 }
 
@@ -92,5 +94,9 @@ func write(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return secretStore.Write(cmd.Context(), secretId, value)
+	if len(tags) > 0 {
+		return secretStore.WriteWithTags(cmd.Context(), secretId, value, tags)
+	} else {
+		return secretStore.Write(cmd.Context(), secretId, value)
+	}
 }

--- a/store/nullstore.go
+++ b/store/nullstore.go
@@ -17,6 +17,10 @@ func (s *NullStore) Write(ctx context.Context, id SecretId, value string) error 
 	return errors.New("Write is not implemented for Null Store")
 }
 
+func (s *NullStore) WriteWithTags(ctx context.Context, id SecretId, value string, tags map[string]string) error {
+	return errors.New("WriteWithTags is not implemented for Null Store")
+}
+
 func (s *NullStore) Read(ctx context.Context, id SecretId, version int) (Secret, error) {
 	return Secret{}, errors.New("Not implemented for Null Store")
 }

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -131,6 +131,10 @@ func (s *S3Store) Write(ctx context.Context, id SecretId, value string) error {
 	return s.writeLatest(ctx, id.Service, index)
 }
 
+func (s *S3Store) WriteWithTags(ctx context.Context, id SecretId, value string, tags map[string]string) error {
+	return errors.New("Not implemented for S3 Store")
+}
+
 func (s *S3Store) Read(ctx context.Context, id SecretId, version int) (Secret, error) {
 	obj, ok, err := s.readObjectById(ctx, id)
 	if err != nil {

--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -138,6 +138,10 @@ func (s *S3KMSStore) Write(ctx context.Context, id SecretId, value string) error
 	return s.writeLatest(ctx, id.Service, index)
 }
 
+func (s *S3KMSStore) WriteWithTags(ctx context.Context, id SecretId, value string, tags map[string]string) error {
+	return errors.New("Not implemented for S3 KMS Store")
+}
+
 func (s *S3KMSStore) ListServices(ctx context.Context, service string, includeSecretName bool) ([]string, error) {
 	return nil, fmt.Errorf("S3KMS Backend is experimental and does not implement this command")
 }

--- a/store/secretsmanagerstore.go
+++ b/store/secretsmanagerstore.go
@@ -215,6 +215,10 @@ func (s *SecretsManagerStore) Write(ctx context.Context, id SecretId, value stri
 	return nil
 }
 
+func (s *SecretsManagerStore) WriteWithTags(ctx context.Context, id SecretId, value string, tags map[string]string) error {
+	return errors.New("tags on write not implemented for Secrets Manager Store")
+}
+
 // Read reads a secret at a specific version.
 // To grab the latest version, use -1 as the version number.
 func (s *SecretsManagerStore) Read(ctx context.Context, id SecretId, version int) (Secret, error) {

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -89,6 +89,14 @@ func (s *SSMStore) KMSKey() string {
 // Write writes a given value to a secret identified by id.  If the secret
 // already exists, then write a new version.
 func (s *SSMStore) Write(ctx context.Context, id SecretId, value string) error {
+	return s.write(ctx, id, value, nil)
+}
+
+func (s *SSMStore) WriteWithTags(ctx context.Context, id SecretId, value string, tags map[string]string) error {
+	return s.write(ctx, id, value, tags)
+}
+
+func (s *SSMStore) write(ctx context.Context, id SecretId, value string, tags map[string]string) error {
 	version := 1
 	// first read to get the current version
 	current, err := s.Read(ctx, id, -1)
@@ -97,6 +105,10 @@ func (s *SSMStore) Write(ctx context.Context, id SecretId, value string) error {
 	}
 	if err == nil {
 		version = current.Meta.Version + 1
+	}
+
+	if len(tags) > 0 && version != 1 {
+		return errors.New("tags on write only supported for new secrets")
 	}
 
 	putParameterInput := &ssm.PutParameterInput{
@@ -112,6 +124,12 @@ func (s *SSMStore) Write(ctx context.Context, id SecretId, value string) error {
 	_, err = s.svc.PutParameter(ctx, putParameterInput)
 	if err != nil {
 		return err
+	}
+
+	if len(tags) > 0 {
+		if err := s.WriteTags(ctx, id, tags, false); err != nil {
+			return fmt.Errorf("failed to write tags on successfully created secret: %w", err)
+		}
 	}
 
 	return nil

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -474,6 +474,39 @@ func TestWritePaths(t *testing.T) {
 	})
 }
 
+func TestWriteWithTags(t *testing.T) {
+	ctx := context.Background()
+	parameters := map[string]mockParameter{}
+	store := NewTestSSMStore(parameters)
+
+	t.Run("Setting a new key with tags should work", func(t *testing.T) {
+		secretId := SecretId{Service: "test", Key: "mykey"}
+		tags := map[string]string{
+			"tag1": "value1",
+			"tag2": "value2",
+		}
+		err := store.WriteWithTags(ctx, secretId, "value", tags)
+		assert.Nil(t, err)
+		assert.Contains(t, parameters, store.idToName(secretId))
+
+		paramTags := parameters[store.idToName(secretId)].tags
+		assert.Equal(t, "value1", paramTags["tag1"])
+		assert.Equal(t, "value2", paramTags["tag2"])
+	})
+
+	t.Run("Setting a existing key with tags should fail", func(t *testing.T) {
+		secretId := SecretId{Service: "test", Key: "mykey"}
+		tags := map[string]string{
+			"tag3": "value3",
+		}
+		err := store.WriteWithTags(ctx, secretId, "newvalue", tags)
+		assert.Error(t, err)
+
+		assert.Contains(t, parameters, store.idToName(secretId))
+		assert.Equal(t, "value", *parameters[store.idToName(secretId)].currentParam.Value) // unchanged
+	})
+}
+
 func TestReadPaths(t *testing.T) {
 	ctx := context.Background()
 	parameters := map[string]mockParameter{}

--- a/store/store.go
+++ b/store/store.go
@@ -61,6 +61,7 @@ type ChangeEvent struct {
 
 type Store interface {
 	Write(ctx context.Context, id SecretId, value string) error
+	WriteWithTags(ctx context.Context, id SecretId, value string, tags map[string]string) error
 	Read(ctx context.Context, id SecretId, version int) (Secret, error)
 	WriteTags(ctx context.Context, id SecretId, tags map[string]string, deleteOtherTags bool) error
 	ReadTags(ctx context.Context, id SecretId) (map[string]string, error)


### PR DESCRIPTION
Store implementations may support tagging secrets immediately after they
are created, as a convenience and a basis for future enforcement of
tagging. As usual, only the SSM store implementation supports the new
feature.

The README is updated with documentation about both this new feature and
the recently added tag commands.
