### PR TITLE
fix: Do not escape exclamation points when exporting to dotenv

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -14,7 +14,8 @@ import (
 )
 
 // originally ported from github.com/joho/godotenv
-const doubleQuoteSpecialChars = "\\\n\r\"!$`"
+// exclamation point removed; ruby and node dotenv libraries do not escape it
+const doubleQuoteSpecialChars = "\\\n\r\"$`"
 
 var (
 	// envCmd represents the env command

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -51,3 +51,26 @@ func Test_sanitizeKey(t *testing.T) {
 		})
 	}
 }
+
+func Test_doubleQuoteEscape(t *testing.T) {
+	tests := []struct {
+		given    string
+		expected string
+	}{
+		{given: "ordinary string", expected: "ordinary string"},
+		{given: `string\with\backslashes`, expected: `string\\with\\backslashes`},
+		{given: "string\nwith\nnewlines", expected: `string\nwith\nnewlines`},
+		{given: "string\rwith\rcarriage returns", expected: `string\rwith\rcarriage returns`},
+		{given: `string"with"quotation marks`, expected: `string\"with\"quotation marks`},
+		{given: `string!with!excl`, expected: `string!with!excl`}, // do not escape !
+		{given: `string$with$dollar signs`, expected: `string\$with\$dollar signs`},
+	}
+
+	for _, tt := range tests {
+		t.Run("test sanitizing key names", func(t *testing.T) {
+			if got := doubleQuoteEscape(tt.given); got != tt.expected {
+				t.Errorf("shellName error: want %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Despite the github.com/joho/godotenv implementation which originated
dotenv support here, neither github.com/bkeepers/dotenv (Ruby) nor
github.com/motdotla/dotenv (Node) escape exclamation points in the
format. See https://github.com/segmentio/chamber/issues/485 for
research.

Fixes #485
