### PR TITLE
feat!: Add store configuration support for SSM store

### DIFF
--- a/store/nullstore.go
+++ b/store/nullstore.go
@@ -13,6 +13,16 @@ func NewNullStore() *NullStore {
 	return &NullStore{}
 }
 
+func (s *NullStore) Config(ctx context.Context) (StoreConfig, error) {
+	return StoreConfig{
+		Version: LatestStoreConfigVersion,
+	}, nil
+}
+
+func (s *NullStore) SetConfig(ctx context.Context, config StoreConfig) error {
+	return errors.New("SetConfig is not implemented for Null Store")
+}
+
 func (s *NullStore) Write(ctx context.Context, id SecretId, value string) error {
 	return errors.New("Write is not implemented for Null Store")
 }

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -72,6 +72,16 @@ func NewS3StoreWithBucket(ctx context.Context, numRetries int, bucket string) (*
 	}, nil
 }
 
+func (s *S3Store) Config(ctx context.Context) (StoreConfig, error) {
+	return StoreConfig{
+		Version: LatestStoreConfigVersion,
+	}, nil
+}
+
+func (s *S3Store) SetConfig(ctx context.Context, config StoreConfig) error {
+	return errors.New("Not implemented for S3 Store")
+}
+
 func (s *S3Store) Write(ctx context.Context, id SecretId, value string) error {
 	index, err := s.readLatest(ctx, id.Service)
 	if err != nil {

--- a/store/secretsmanagerstore.go
+++ b/store/secretsmanagerstore.go
@@ -114,6 +114,16 @@ func NewSecretsManagerStore(ctx context.Context, numRetries int) (*SecretsManage
 	}, nil
 }
 
+func (s *SecretsManagerStore) Config(ctx context.Context) (StoreConfig, error) {
+	return StoreConfig{
+		Version: LatestStoreConfigVersion,
+	}, nil
+}
+
+func (s *SecretsManagerStore) SetConfig(ctx context.Context, config StoreConfig) error {
+	return errors.New("Not implemented for Secrets Manager Store")
+}
+
 // Write writes a given value to a secret identified by id. If the secret
 // already exists, then write a new version.
 func (s *SecretsManagerStore) Write(ctx context.Context, id SecretId, value string) error {

--- a/store/secretsmanagerstore_test.go
+++ b/store/secretsmanagerstore_test.go
@@ -477,3 +477,13 @@ func uniqueID() string {
 	_, _ = rand.Read(uuid)
 	return fmt.Sprintf("%x", uuid)
 }
+
+func TestSecretsManagerStoreConfig(t *testing.T) {
+	store := &SecretsManagerStore{}
+
+	config, err := store.Config(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, LatestStoreConfigVersion, config.Version)
+	assert.Empty(t, config.RequiredTags)
+}

--- a/store/store.go
+++ b/store/store.go
@@ -15,6 +15,18 @@ func ReservedService(service string) bool {
 	return service == ChamberService
 }
 
+const (
+	LatestStoreConfigVersion = "1"
+)
+
+// StoreConfig holds configuration information for a store. WARNING: Despite
+// its public visibility, the contents of this struct are subject to change at
+// any time, and are not part of the public interface for chamber.
+type StoreConfig struct {
+	Version      string   `json:"version"`
+	RequiredTags []string `json:"requiredTags,omitempty"`
+}
+
 type ChangeEventType int
 
 const (
@@ -73,6 +85,8 @@ type ChangeEvent struct {
 
 // Store is an interface for a secret store.
 type Store interface {
+	Config(ctx context.Context) (StoreConfig, error)
+	SetConfig(ctx context.Context, config StoreConfig) error
 	Write(ctx context.Context, id SecretId, value string) error
 	WriteWithTags(ctx context.Context, id SecretId, value string, tags map[string]string) error
 	Read(ctx context.Context, id SecretId, version int) (Secret, error)


### PR DESCRIPTION
The new Config and SetConfig methods on the Store interface allow
implementations to maintain their own configurations. Only the SSM store
fully implements the methods; the others return an empty configuration
and do not support setting one.

The store configuration itself holds a list of required tags for each
written secret. Enforcement of the tags is not yet implemented. Although
the configuration struct is exported from its package, it is not part of
chamber's client interface and is subject to change at any time.

The SSM store implementation stores its configuration as a secret
inside the newly reserved "_chamber" service as a JSON document. The
schema is not exported, so users shouldn't build anything from it.
