### PR TITLE
fix: Find region correctly from EC2 IMDS

### DIFF
--- a/store/shared.go
+++ b/store/shared.go
@@ -31,10 +31,11 @@ func getConfig(ctx context.Context, numRetries int, retryMode aws.RetryMode) (aw
 	// If region is still not set, attempt to determine it via ec2 metadata API
 	if cfg.Region == "" {
 		imdsConfig, err := config.LoadDefaultConfig(ctx)
-		if err != nil {
+		if err == nil {
 			ec2metadataSvc := imds.NewFromConfig(imdsConfig)
 			if regionOverride, err := ec2metadataSvc.GetRegion(ctx, &imds.GetRegionInput{}); err == nil {
 				region = regionOverride.Region
+				cfg.Region = region
 			}
 		}
 	}


### PR DESCRIPTION
When running on an EC2 instance with an instance profile / role, chamber
now finds the region correctly.
