### PR TITLE
ci(dependabot): group aws-sdk-go-v2 updates into a single pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      aws-sdk-go:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2"
+          - "github.com/aws/aws-sdk-go-v2/*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Group Dependabot PRs for `aws-sdk-go-v2` into a single grouped pull request

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

With the swap to `aws-sdk-go-v2`, each AWS SDK dependency is treated as a unique package and opens a new PR
![image](https://github.com/user-attachments/assets/4edf9f4f-5504-4b94-a376-65b762e91359)

This is extremely noisy and expensive for GitHub actions usage.