### PR TITLE
all: replace gopkg.in/yaml.v3 with github.com/goccy/go-yaml

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -9,12 +9,11 @@ import (
 	"os"
 	"strings"
 
+	yaml "github.com/goccy/go-yaml"
 	"github.com/magiconair/properties"
-
 	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v3/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // exportCmd represents the export command

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -5,11 +5,11 @@ import (
 	"io"
 	"os"
 
+	yaml "github.com/goccy/go-yaml"
 	analytics "github.com/segmentio/analytics-go/v3"
 	"github.com/segmentio/chamber/v3/store"
 	"github.com/segmentio/chamber/v3/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.4
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.6
 	github.com/aws/smithy-go v1.22.1
+	github.com/goccy/go-yaml v1.17.1
 	github.com/magiconair/properties v1.8.9
 	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.29.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -42,4 +42,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/segmentio/backo-go v1.0.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=


### PR DESCRIPTION
The former project has been archived and does not have any commits for three years.