### PR TITLE
Golang & codecov updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         run: make coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: segmentio/chamber

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-alpine AS build
+FROM golang:1.24.4-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .


### PR DESCRIPTION
PR to bump Golang version to 1.24.4 to address CVE-2025-22874. This was already done in https://github.com/segmentio/chamber/pull/626 but it failed due to EPIPE errors. As such also bumping the codecov-action to the newest 4.x release to avoid that going forward.

fixes https://github.com/segmentio/chamber/issues/627

Tagging @Fauzyy @alecjacobs5401 as the two most recent committers on this project. Happy for y'all to close this in favor of #626 if desired. Thanks!