### PR TITLE
chore - Update Go to 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.4-alpine AS build
+FROM golang:1.25.5-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine AS build
+FROM golang:1.25.6-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6-alpine AS build
+FROM golang:1.25.7-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .


### PR DESCRIPTION
## Problem

The current version of Go, 1.25.4, has the following vulnerabilities:

- CVE-2025-61729
- CVE-2025-61727

However, both of these have been addressed by Go version 1.25.5.

In addition, 1.25.5 has some vulnerabilities:

- CVE-2025-61726
- CVE-2025-61728
- CVE-2025-61730

## Solution

- Bump the Dockerfile version to 1.25.7.