### PR TITLE
chore - Update Go to 1.26.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   install-go-modules:
     strategy:
       matrix:
-        go: ["1.25.x", "1.24.x", "1.23.x"]
+        go: ["1.26.x", "1.25.x", "1.24.x"]
 
     runs-on: ubuntu-latest
 
@@ -28,7 +28,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.25.x", "1.24.x", "1.23.x"]
+        go: ["1.26.x", "1.25.x", "1.24.x"]
     runs-on: ubuntu-latest
 
     steps:
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.x"
 
       - name: Run coverage
         run: make coverage
@@ -76,7 +76,7 @@ jobs:
   dist:
     strategy:
       matrix:
-        go: ["1.25.x", "1.24.x", "1.23.x"]
+        go: ["1.26.x", "1.25.x", "1.24.x"]
     runs-on: ubuntu-latest
     needs: test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: Install nfpm, rpmbuild
         run: sudo make -f Makefile.tools nfpm-debian rpmbuild-debian
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine AS build
+FROM golang:1.26.2-alpine AS build
 
 WORKDIR /go/src/github.com/segmentio/chamber
 COPY . .


### PR DESCRIPTION
## Problem

The current version of Go, 1.25.7, has the following vulnerabilities:

- CVE-2026-25679
- CVE-2026-32280
- CVE-2026-32281
- CVE-2026-32283
- CVE-2026-27142
- CVE-2026-32282
- CVE-2026-32288
- CVE-2026-32289
- CVE-2026-27139

These have been addressed by Go version 1.26.2

## Solution

- Bump the Dockerfile version to 1.26.2
- Add 1.26.x to the GH build workflow, ejecting 1.23.x
- Add 1.26.x to the GH release workflow, ejecting 1.23.x